### PR TITLE
Fix value_to and value_from for MSVC-14.0:

### DIFF
--- a/include/boost/json/detail/value_from.hpp
+++ b/include/boost/json/detail/value_from.hpp
@@ -83,11 +83,13 @@ tag_invoke(
 // Generic conversions
 
 // string-like types
+// NOTE: original check for size used is_convertible but 
+// MSVC-140 selects wrong specialisation if used
 template<class T, typename std::enable_if<
     std::is_constructible<remove_cvref<T>, const char*, std::size_t>::value &&
-        std::is_convertible<decltype(std::declval<T&>().data()), const char*>::value && 
-    std::is_convertible<decltype(std::declval<T&>().size()),
-        std::size_t>::value>::type* = nullptr>
+    std::is_convertible<decltype(std::declval<T&>().data()), const char*>::value && 
+    std::is_integral<decltype(std::declval<T&>().size())>::value
+>::type* = nullptr>
 void 
 value_from_generic(
     value& jv,

--- a/include/boost/json/detail/value_to.hpp
+++ b/include/boost/json/detail/value_to.hpp
@@ -100,11 +100,13 @@ tag_invoke(
 // Use generic conversion
 
 // string-like types
+// NOTE: original check for size used is_convertible but 
+// MSVC-140 selects wrong specialisation if used
 template<class T, typename std::enable_if<
     std::is_constructible<T, const char*, std::size_t>::value &&
-        std::is_convertible<decltype(std::declval<T&>().data()), const char*>::value && 
-    std::is_convertible<decltype(std::declval<T&>().size()),
-        std::size_t>::value>::type* = nullptr>
+    std::is_convertible<decltype(std::declval<T&>().data()), const char*>::value && 
+    std::is_integral<decltype(std::declval<T&>().size())>::value
+>::type* = nullptr>
 T
 value_to_generic(
     const value& jv,


### PR DESCRIPTION
value_to and value_from was incorrectly deducing that std::string was
"array-like" rather than "string-like", but only on msvc-14.0

Original test:

template<class T, typename std::enable_if<
    std::is_constructible<remove_cvref<T>, const char*, std::size_t>::value &&
    std::is_convertible<decltype(std::declval<T&>().data()), const char*>::value &&
    std::is_convertible<decltype(std::declval<T&>().size()), std::size_t>::value
>::type* = nullptr>

Which works for all compilers except msvc-14.0

New test:

template<class T, typename std::enable_if<
    std::is_constructible<remove_cvref<T>, const char*, std::size_t>::value &&
    std::is_convertible<decltype(std::declval<T&>().data()), const char*>::value &&
    std::is_integral<decltype(std::declval<T&>().size())>::value
>::type* = nullptr>

Note that each individual test works on all compilers. It seems to be
the conjuction of tests that caused msvc-14 to trip up.