### PR TITLE
Add function overload throw_exception

### DIFF
--- a/include/boost/json/detail/impl/except.ipp
+++ b/include/boost/json/detail/impl/except.ipp
@@ -45,10 +45,18 @@ namespace detail {
 template<class E>
 void
 BOOST_NORETURN
+#if BOOST_VERSION >= 107300
+throw_exception(E e, source_location const& loc)
+{
+    (void)loc;
+    throw e;
+}
+#else
 throw_exception(E e)
 {
     throw e;
 }
+#endif
 #endif
 
 void


### PR DESCRIPTION
There is no function overload for boost version >= 1.73.0
close #398