### PR TITLE
Adds GCC 4.8 support

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -11,16 +11,23 @@ import ../config/checks/config : requires ;
 
 # These make sure we only build on
 # compatible C++11 or later toolchains.
-constant c11-requires :
-    [ requires
-    cxx11_alignas
-    cxx11_constexpr
-    cxx11_decltype
-    cxx11_hdr_tuple
-    cxx11_template_aliases
-    cxx11_variadic_templates
-    ]
+obj check_basic_alignas : check/basic_alignas.cpp ;
+alias c11-requires
+    : requirements
+      [ requires
+      cxx11_constexpr
+      cxx11_decltype
+      cxx11_hdr_tuple
+      cxx11_template_aliases
+      cxx11_variadic_templates
+      ]
+      # We only require limited alignas support,
+      # so we have to use a custom check
+      [ check-target-builds
+      check_basic_alignas cxx11_basic_alignas : : <build>no
+      ]
     ;
+explicit basic_alignas c11-requires ;
 
 path-constant LIB_DIR : . ;
 

--- a/bench/Jamfile
+++ b/bench/Jamfile
@@ -22,7 +22,7 @@ else
     LIB = <library>/boost/json//boost_json ;
 }
 
-project : requirements $(c11-requires) ;
+project : requirements <source>..//c11-requires ;
 
 exe bench :
     bench.cpp

--- a/check/basic_alignas.cpp
+++ b/check/basic_alignas.cpp
@@ -1,0 +1,9 @@
+struct some_struct {
+    double d;
+    int n;
+    void* ptr;
+};
+
+alignas(16) char test1[10];
+alignas(double) char test2[10];
+alignas(some_struct) char test3[10];

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -22,7 +22,7 @@ else
     LIB = <library>/boost/json//boost_json ;
 }
 
-project : requirements $(c11-requires) ;
+project : requirements <source>..//c11-requires ;
 
 exe path :
     path.cpp

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -72,7 +72,7 @@ local LIMIT_SOURCES =
 
 local RUN_TESTS ;
 
-project : requirements $(c11-requires) ;
+project : requirements <source>..//c11-requires ;
 
 for local f in $(SOURCES)
 {
@@ -84,7 +84,7 @@ for local f in $(SOURCES)
 }
 
 RUN_TESTS += [
-    run memory_resource.cpp main.cpp 
+    run memory_resource.cpp main.cpp
         /boost//container/<warnings-as-errors>off
         : : :
         $(LIB)


### PR DESCRIPTION
Fixes #491 
GCC 4.8 has alignas support, but has bugs. These bugs do not, however,
affect Boost.Json, as it requires only the basic functionality. This
commit replaces Boost.Config's check for alignas with a custom one, that
tests for alignas functionality that is used in this library.