### PR TITLE
side-cast(?) from [object,array,string] to value

### DIFF
--- a/include/boost/json/array.hpp
+++ b/include/boost/json/array.hpp
@@ -1590,6 +1590,24 @@ public:
     void
     swap(array& other);
 
+    BOOST_JSON_DECL
+    operator value& () &
+    {
+        return reinterpret_cast<value&>(*this);
+    }
+
+    BOOST_JSON_DECL
+    operator value const& () const&
+    {
+        return reinterpret_cast<value const&>(*this);
+    }
+
+    BOOST_JSON_DECL
+    explicit operator value&& () &&
+    {
+        return reinterpret_cast<value&&>(*this);
+    }
+
     /** Exchange the given values.
 
         Exchanges the contents of the array `lhs` with
@@ -1610,7 +1628,7 @@ public:
         @code
         lhs.swap( rhs );
         @endcode
-        
+
         @par Complexity
         Constant or linear in `lhs.size() + rhs.size()`.
 

--- a/include/boost/json/impl/array.ipp
+++ b/include/boost/json/impl/array.ipp
@@ -191,6 +191,7 @@ array(detail::unchecked_array&& ua)
 array::
 ~array()
 {
+    if (k_ != json::kind::array) return;
     destroy();
 }
 

--- a/include/boost/json/impl/object.ipp
+++ b/include/boost/json/impl/object.ipp
@@ -240,6 +240,8 @@ object(detail::unchecked_object&& uo)
 object::
 ~object()
 {
+    if(k_ != json::kind::object)
+        return;
     if(sp_.is_not_shared_and_deallocate_is_trivial())
         return;
     if(t_->capacity == 0)

--- a/include/boost/json/object.hpp
+++ b/include/boost/json/object.hpp
@@ -1438,6 +1438,24 @@ public:
     value*
     if_contains(string_view key) noexcept;
 
+    BOOST_JSON_DECL
+    operator value& () &
+    {
+        return reinterpret_cast<value&>(*this);
+    }
+
+    BOOST_JSON_DECL
+    operator value const& () const&
+    {
+        return reinterpret_cast<value const&>(*this);
+    }
+
+    BOOST_JSON_DECL
+    explicit operator value&& () &&
+    {
+        return reinterpret_cast<value&&>(*this);
+    }
+
     /** Return `true` if two objects are equal.
 
         Objects are equal when their sizes are the same,

--- a/include/boost/json/string.hpp
+++ b/include/boost/json/string.hpp
@@ -2369,6 +2369,24 @@ public:
     void
     swap(string& other);
 
+    BOOST_JSON_DECL
+    operator value& () &
+    {
+        return reinterpret_cast<value&>(*this);
+    }
+
+    BOOST_JSON_DECL
+    operator value const& () const&
+    {
+        return reinterpret_cast<value const&>(*this);
+    }
+
+    BOOST_JSON_DECL
+    explicit operator value&& () &&
+    {
+        return reinterpret_cast<value&&>(*this);
+    }
+
     /** Exchange the given values.
 
         Exchanges the contents of the string `lhs` with

--- a/include/boost/json/value.hpp
+++ b/include/boost/json/value.hpp
@@ -681,8 +681,8 @@ public:
 
         @param other The string to construct with.
     */
-    value(
-        string other) noexcept
+    explicit value(
+        string&& other) noexcept
         : str_(std::move(other))
     {
     }
@@ -799,7 +799,7 @@ public:
 
         @param other The array to construct with.
     */
-    value(array other) noexcept
+    explicit value(array&& other) noexcept
         : arr_(std::move(other))
     {
     }
@@ -916,7 +916,7 @@ public:
 
         @param other The object to construct with.
     */
-    value(object other) noexcept
+    explicit value(object&& other) noexcept
         : obj_(std::move(other))
     {
     }


### PR DESCRIPTION
We can cast ```json::value``` to array, object, string with ```get_array()```, ```get_object()```, ```get_string()``` member functions, but we can't cast them back to ```json::value```.

Suppose we write a function that take ```json::value``` as argument and return reference to sub-value:
```c++
json::value&       query(json::value&); // (1)
json::value const& query(json::value const&); // (2)
```
Suppose everything works fine as long as we pass ```json::value``` as interface stated. 

Things go sideway when we call ```query``` with ```json::object``` as argument. The object is converted to temporary ```json::value``` and bound to ```json::value const&``` on (2) then function will return reference to (most-likely destroyed) sub-value of temporary.

Situation is more serious if functions are modifier:
```c++
json::value& modify(json::value&); // (3)
json::value&& modify(json::value&&); // (4)

json::array a1 { 100, 200 };
auto&& a2 = modify(a1);
```
Client code expect ```a1``` to be changed after function call, but that is not what is going to happen. ```a1``` is converted to temporary ```json::value```, then bound to argument of (4) and ```modify``` change this temporary and return reference to it. 

To avoid this fiasco, we need to supply overload for ```json::[array,object,string]``` to each functions.
```c++
json::value&       query(json::array&);
json::value const& query(json::array const&);
json::value&       query(json::object&);
json::value const& query(json::object const&);
```
It seems fine but it soon become ridiculous when we have multiple ```json::value``` argument.

All of these problems go away if reference to ```json::[array,object,string]``` can be implicitly casted to reference to ```json::value```. 

So I fork the repository. Everything is working fine except conversion to rvalue-ref ```json::value&&```. It has to be explicit otherwise it cause ambiguity issue with ```json::value const&```.

Are there any issue that make you to decide not support this in the first place?
Supporting this might seems odd from normal C++ OO perspective because ```json::[array,object,string,value]``` are distinct types, but it is intuitive considering they are modeled after JavaScript value. I thought you were worrying about use-case like:
```c++
json::array a1 { 100, 200 };
static_cast<json::value&>(a1) = "yahoo";
a1[1]; // KABOOM
```
but this problem already exist:
```c++
json::value v1 { 100, 200 };
auto& a1 = v1.get_array();
v1 = "yahoo";
a1[1]; // KABOOM
```