### PR TITLE
Replace sed-based customization with XSLT import:

### DIFF
--- a/doc/Jamfile
+++ b/doc/Jamfile
@@ -96,25 +96,13 @@ make common.xsl                 : $(docca)/include/docca/common.xsl             
 make stage1.xsl                 : $(docca)/include/docca/stage1.xsl                 : @copy_script ;
 make base-stage1.xsl            : $(docca)/include/docca/base-stage1.xsl            : @copy_script ;
 make stage2.xsl                 : $(docca)/include/docca/stage2.xsl                 : @copy_script ;
+make base-stage2.xsl            : $(docca)/include/docca/base-stage2.xsl            : @copy_script ;
 make assemble-quickbook.xsl     : $(docca)/include/docca/assemble-quickbook.xsl     : @copy_script ;
 make emphasized-types.xsl       : $(docca)/include/docca/emphasized-types.xsl       : @copy_script ;
+make base-config.xsl            : $(docca)/include/docca/base-config.xsl            : @copy_script ;
 
-make config.xsl
-    :
-        $(docca)/include/docca/config.xsl
-        xsl/config.xsl
-        xsl/class_detail.xsl
-        xsl/includes.xsl
-    :
-        @make_config
-    ;
-
-actions make_config
-{
-    cp $(2[1]) $(1)
-    sed -i -e "/<!-- CONFIG_TEMPLATE -->/{r $(2[2])" -e "d}" $(1)
-    sed -i -e "/<!-- INCLUDES_FOOT_TEMPLATE -->/{r $(2[4])" -e "d}" $(1)
-}
+# Copy the project-specific config XSLT
+make custom-overrides.xsl : xsl/custom-overrides.xsl : @copy_script ;
 
 # Make a copy of the given file.
 #
@@ -139,7 +127,8 @@ make xml-pages.xml
 
         # Make bjam aware of additional dependencies
         base-extract-xml-pages.xsl
-        config.xsl
+        base-config.xsl
+        custom-overrides.xsl
         common.xsl
     :
         saxonhe.saxonhe
@@ -170,7 +159,8 @@ make stage1/results
         # additional dependencies
         xml-pages.xml
         base-stage1.xsl
-        config.xsl
+        base-config.xsl
+        custom-overrides.xsl
         common.xsl
     :
         saxonhe.saxonhe_dir
@@ -183,6 +173,10 @@ make stage2/results
 
         # additional dependencies
         emphasized-types.xsl
+        base-stage2.xsl
+        base-config.xsl
+        custom-overrides.xsl
+        common.xsl
     :
         saxonhe.saxonhe_dir
     ;

--- a/doc/xsl/class_detail.xsl
+++ b/doc/xsl/class_detail.xsl
@@ -1,6 +1,0 @@
-<!-- CLASS_DETAIL_TEMPLATE BEGIN -->
-<xsl:when test="$normal-tparam = 'Allocator'"><xsl:text>__Allocator__</xsl:text></xsl:when>
-<xsl:when test="$normal-tparam = 'InputIterator'"><xsl:text>__InputIterator__</xsl:text></xsl:when>
-<xsl:when test="$normal-tparam = 'ConstBufferSequence'"><xsl:text>__ConstBufferSequence__</xsl:text></xsl:when>
-<xsl:when test="$normal-tparam = 'MutableBufferSequence'"><xsl:text>__MutableBufferSequence__</xsl:text></xsl:when>
-<!-- CLASS_DETAIL_TEMPLATE END -->

--- a/doc/xsl/config.xsl
+++ b/doc/xsl/config.xsl
@@ -1,6 +1,0 @@
-<!-- Variables (Edit for your project) -->
-<xsl:variable name="doc-ref" select="'json.ref'"/>
-<xsl:variable name="doc-ns" select="'boost::json'"/>
-<xsl:variable name="debug" select="0"/>
-<xsl:variable name="include-private-members" select="false()"/>
-<!-- End Variables -->

--- a/doc/xsl/custom-overrides.xsl
+++ b/doc/xsl/custom-overrides.xsl
@@ -1,4 +1,13 @@
-<!-- INCLUDES_FOOT_TEMPLATE BEGIN -->
+<xsl:stylesheet version="3.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  exclude-result-prefixes="xs"
+  expand-text="yes">
+
+  <xsl:variable name="doc-ref" select="'json.ref'"/>
+  <xsl:variable name="doc-ns" select="'boost::json'"/>
+  <xsl:variable name="include-private-members" select="false()"/>
+
   <xsl:template mode="includes-template-footer" match="location">
     <xsl:variable name="convenience-header" as="xs:string?">
       <xsl:apply-templates mode="convenience-header" select="@file"/>
@@ -12,4 +21,5 @@
 
   <xsl:template mode="convenience-header" match="@file[contains(., 'boost/json')]">json.hpp</xsl:template>
   <xsl:template mode="convenience-header" match="@file"/>
-<!-- INCLUDES_FOOT_TEMPLATE END -->
+
+</xsl:stylesheet>


### PR DESCRIPTION
fix boostorg/docca#40

This must be updated in parallel with the corresponding change in boostorg/docca. Otherwise, the doc build will fail.