### PR TITLE
Fix some typo error in value, string and conversion documents.

### DIFF
--- a/doc/qbk/03_01_value.qbk
+++ b/doc/qbk/03_01_value.qbk
@@ -56,7 +56,7 @@ may be used to check whether or not the value is a particular kind:
 [snippet_value_2]
 
 Functions like
-[link json.ref.boost__json__value.is_object `value::is_object`]
+[link json.ref.boost__json__value.if_object `value::if_object`]
 actually return a pointer to the object if the value is an object,
 otherwise they return null. This allows them to be used both in
 boolean contexts as above, and in assignments or conditional

--- a/doc/qbk/03_02_string.qbk
+++ b/doc/qbk/03_02_string.qbk
@@ -53,7 +53,7 @@ following parameter combinations as an input string:
 * a parameter of type `const_pointer` and a `size_type` parameter
 that specifies the length of the string
 
-are replaced with with an overload accepting a __string_view__ parameter.
+are replaced with an overload accepting a __string_view__ parameter.
 
 This design removes several redundant overloads from the interface.
 For example, the 11 overloads of `std::string::insert` are reduced

--- a/doc/qbk/03_06_conversion.qbk
+++ b/doc/qbk/03_06_conversion.qbk
@@ -22,7 +22,7 @@ The conversion in the opposite direction is done with __value_to__.
 [heading Customization Points]
 
 A ['customization point] is a mechanism where a library delegates behavior
-of some operation to the user, or gives the use the option of controlling
+of some operation to the user, or gives the user the option of controlling
 the behavior of some operation for a specific type.
 Within the standard library, the `swap` function is a customization point
 that uses [@https://en.cppreference.com/w/cpp/language/adl argument-dependent lookup]


### PR DESCRIPTION
Found some typo while reading the doc then submit patch to fix the typo.

Signed-off-by: Liang Yan