### PR TITLE
Prefix tests in CMake with boost_json

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,19 +14,19 @@ if(BOOST_JSON_STANDALONE)
 endif()
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES ${BOOST_JSON_TESTS_FILES})
-add_executable(tests ${BOOST_JSON_TESTS_FILES})
-target_include_directories(tests PRIVATE .)
-target_link_libraries(tests PRIVATE Boost::json)
-add_test(NAME json-tests COMMAND tests)
+add_executable(boost_json-tests ${BOOST_JSON_TESTS_FILES})
+target_include_directories(boost_json-tests PRIVATE .)
+target_link_libraries(boost_json-tests PRIVATE Boost::json)
+add_test(NAME boost_json-tests COMMAND boost_json-tests)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "" FILES limits.cpp main.cpp)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/../src PREFIX "" FILES ../src/src.cpp)
-add_executable(limits limits.cpp main.cpp ../src/src.cpp Jamfile)
+add_executable(boost_json-limits limits.cpp main.cpp ../src/src.cpp Jamfile)
 
-target_compile_features(limits PUBLIC cxx_constexpr)
+target_compile_features(boost_json-limits PUBLIC cxx_constexpr)
 
-target_include_directories(limits PRIVATE ../include .)
-target_compile_definitions(limits PRIVATE
+target_include_directories(boost_json-limits PRIVATE ../include .)
+target_compile_definitions(boost_json-limits PRIVATE
     BOOST_JSON_MAX_STRING_SIZE=1000
     BOOST_JSON_MAX_STRUCTURED_SIZE=20
     BOOST_JSON_STACK_BUFFER_SIZE=256
@@ -34,10 +34,10 @@ target_compile_definitions(limits PRIVATE
 )
 
 if(BOOST_JSON_STANDALONE)
-    target_compile_definitions(limits PRIVATE BOOST_JSON_STANDALONE)
-    target_compile_features(limits PRIVATE cxx_std_17)
+    target_compile_definitions(boost_json-limits PRIVATE BOOST_JSON_STANDALONE)
+    target_compile_features(boost_json-limits PRIVATE cxx_std_17)
 elseif(BOOST_SUPERPROJECT_VERSION)
-    target_link_libraries(limits
+    target_link_libraries(boost_json-limits
         PRIVATE
             Boost::align
             Boost::assert
@@ -49,14 +49,14 @@ elseif(BOOST_SUPERPROJECT_VERSION)
             Boost::utility
     )
 elseif(BOOST_JSON_IN_BOOST_TREE)
-    target_include_directories(limits PRIVATE ${BOOST_ROOT})
-    target_link_directories(limits PRIVATE ${BOOST_ROOT}/stage/lib)
+    target_include_directories(boost_json-limits PRIVATE ${BOOST_ROOT})
+    target_link_directories(boost_json-limits PRIVATE ${BOOST_ROOT}/stage/lib)
 else()
-    target_link_libraries(limits
+    target_link_libraries(boost_json-limits
         PRIVATE
             Boost::system
             Boost::container
     )
 endif()
 
-add_test(NAME json-limits COMMAND limits)
+add_test(NAME boost_json-limits COMMAND boost_json-limits)


### PR DESCRIPTION
Fix #535 