### PR TITLE
Do not crash in array constructor from iterators that form an empty range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Boost 1.77.0:
 *  Implicit conversion operator from `string` to `std::string_view`.
 * `value_to` supports `TupleLike` types.
 * `object` deallocates the correct size.
+* Fixed crash when constructing `array` from a pair of iterators that form an
+  empty range.
 
 Boost 1.76.0:
 

--- a/doc/qbk/release_notes.qbk
+++ b/doc/qbk/release_notes.qbk
@@ -21,6 +21,8 @@
 [*Fixes]
 
 * __object__ deallocates the correct size.
+* Fixed crash when constructing __array__ from a pair of iterators that form an
+  empty range.
 
 [*Improvements]
 

--- a/include/boost/json/impl/array.hpp
+++ b/include/boost/json/impl/array.hpp
@@ -493,6 +493,12 @@ array(
 {
     std::size_t n =
         std::distance(first, last);
+    if( n == 0 )
+    {
+        t_ = &empty_;
+        return;
+    }
+
     t_ = table::allocate(n, sp_);
     t_->size = 0;
     revert_construct r(*this);

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -12,6 +12,10 @@
 
 #include <boost/json/monotonic_resource.hpp>
 
+#include <forward_list>
+#include <list>
+#include <iterator>
+
 #include "test.hpp"
 #include "test_suite.hpp"
 
@@ -148,6 +152,29 @@ public:
 
         // array(InputIt, InputIt, storage)
         {
+            // empty range
+            {
+                // random-access iterator
+                std::vector<value> i1;
+                array a1(i1.begin(), i1.end());
+                BOOST_TEST(a1.empty());
+
+                // bidirectional iterator
+                std::list<value> i2;
+                array a2(i2.begin(), i2.end());
+                BOOST_TEST(a2.empty());
+
+                // forward iterator
+                std::forward_list<value> i3;
+                array a3(i3.begin(), i3.end());
+                BOOST_TEST(a3.empty());
+
+                // input iterator
+                auto const it = make_input_iterator(i3.begin());
+                array a4(it, it);
+                BOOST_TEST(a4.empty());
+            }
+
             // default storage
             {
                 init_list init{ 0, 1, str_, 3, 4 };

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -15,6 +15,8 @@
 #include <boost/json/serialize.hpp>
 
 #include <cmath>
+#include <forward_list>
+#include <map>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -325,6 +327,29 @@ public:
 
         // object(InputIt, InputIt, size_type, storage_ptr)
         {
+            // empty range
+            {
+                // random-access iterator
+                std::vector<std::pair<string_view, value>> i1;
+                object o1(i1.begin(), i1.end());
+                BOOST_TEST(o1.empty());
+
+                // bidirectional iterator
+                std::map<string_view, value> i2;
+                object o2(i2.begin(), i2.end());
+                BOOST_TEST(o2.empty());
+
+                // forward iterator
+                std::forward_list<std::pair<string_view, value>> i3;
+                object o3(i3.begin(), i3.end());
+                BOOST_TEST(o3.empty());
+
+                // input iterator
+                auto const it = make_input_iterator(i3.begin());
+                object o4(it, it);
+                BOOST_TEST(o4.empty());
+            }
+
             // small
             {
                 object o(i0_.begin(), i0_.end());

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -1522,7 +1522,7 @@ public:
         BOOST_TEST(res.allocated == res.deallocated);
     }
 
-    void    
+    void
     testHash()
     {
         BOOST_TEST(check_hash_equal(
@@ -1533,7 +1533,7 @@ public:
             object({{"a",1}, {"b",2}, {"c",3}}),
             object({{"b",2}, {"c",3}, {"a",1}})));
         BOOST_TEST(expect_hash_not_equal(
-            object({{"a",1}, {"b",2}, {"c",3}}), 
+            object({{"a",1}, {"b",2}, {"c",3}}),
             object({{"b",2}, {"c",3}})));
     }
 


### PR DESCRIPTION
Fix #567 