### PR TITLE
JSON pointer implementation

### DIFF
--- a/doc/qbk/03_00_dom.qbk
+++ b/doc/qbk/03_00_dom.qbk
@@ -56,5 +56,6 @@ These containers are explored in-depth in the sections that follow.
 [include 03_05_numbers.qbk]
 [include 03_06_conversion.qbk]
 [include 03_07_init_lists.qbk]
+[include 03_08_nested_access.qbk]
 
 [endsect]

--- a/doc/qbk/03_08_nested_access.qbk
+++ b/doc/qbk/03_08_nested_access.qbk
@@ -1,0 +1,29 @@
+[/
+    Copyright (c) 2022 Dmitry Arkhipov (grisumbras@gmail.com)
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    Official repository: https://github.com/cppalliance/json
+]
+
+[/-----------------------------------------------------------------------------]
+
+[section:nested_access Accessing Deeply Nested Elements]
+
+In order to allow conveniently retrieving and changing deeply nested elements
+of __value__ objects the library implements
+[@https://datatracker.ietf.org/doc/html/rfc6901 RFC 6901 (JSON Pointer)]:
+
+[snippet_pointer_1]
+
+This is particularly useful when throwing exceptions is undesirable.
+For example, compare
+
+[snippet_pointer_2]
+
+with
+
+[snippet_pointer_3]
+
+[endsect]

--- a/include/boost/json/detail/digest.hpp
+++ b/include/boost/json/detail/digest.hpp
@@ -14,11 +14,11 @@ BOOST_JSON_NS_BEGIN
 namespace detail {
 
 // Calculate salted digest of string
-inline
+template<class ForwardIterator>
 std::size_t
 digest(
-    char const* s,
-    std::size_t n,
+    ForwardIterator b,
+    ForwardIterator e,
     std::size_t salt) noexcept
 {
 #if BOOST_JSON_ARCH == 64
@@ -29,8 +29,8 @@ digest(
     std::uint32_t hash  = 0x811C9DC5UL;
 #endif
     hash += salt;
-    for(;n--;++s)
-        hash = (*s ^ hash) * prime;
+    for(; b != e; ++b)
+        hash = (*b ^ hash) * prime;
     return hash;
 }
 

--- a/include/boost/json/detail/object.hpp
+++ b/include/boost/json/detail/object.hpp
@@ -11,10 +11,12 @@
 #define BOOST_JSON_DETAIL_OBJECT_HPP
 
 #include <boost/json/storage_ptr.hpp>
+#include <boost/json/string_view.hpp>
 #include <cstdlib>
 
 BOOST_JSON_NS_BEGIN
 
+class object;
 class value;
 class key_value_pair;
 
@@ -72,6 +74,19 @@ public:
         return data;
     }
 };
+
+template<class CharRange>
+std::pair<key_value_pair*, std::size_t>
+find_in_object(
+    object const& obj,
+    CharRange key) noexcept;
+
+extern template
+BOOST_JSON_DECL
+std::pair<key_value_pair*, std::size_t>
+find_in_object<string_view>(
+    object const&,
+    string_view key) noexcept;
 
 } // detail
 BOOST_JSON_NS_END

--- a/include/boost/json/error.hpp
+++ b/include/boost/json/error.hpp
@@ -76,6 +76,31 @@ enum class error
 
     /// test failure
     test_failure,
+
+    //
+    // JSON Pointer errors
+    //
+
+    /// missing slash character before token reference
+    missing_slash,
+
+    /// invalid escape sequence
+    invalid_escape,
+
+    /// token should be a number but cannot be parsed as such
+    token_not_number,
+
+    /// current value is neither an object nor an array
+    value_is_scalar,
+
+    /// current value does not contain referenced value
+    not_found,
+
+    /// token cannot be represented by std::size_t
+    token_overflow,
+
+    /// past-the-end index is not supported
+    past_the_end,
 };
 
 /** Error conditions corresponding to JSON errors
@@ -86,7 +111,13 @@ enum class condition
     parse_error = 1,
 
     /// An error on assignment to or from a JSON value
-    assign_error
+    assign_error,
+
+    /// An error related to parsing JSON pointer string
+    pointer_parse_error,
+
+    /// An error related to applying JSON pointer string to a value
+    pointer_use_error,
 };
 
 BOOST_JSON_NS_END

--- a/include/boost/json/impl/error.ipp
+++ b/include/boost/json/impl/error.ipp
@@ -49,6 +49,14 @@ case error::not_number: return "not a number";
 case error::not_exact: return "not exact";
 
 case error::test_failure: return "test failure";
+
+case error::missing_slash: return "missing slash character";
+case error::invalid_escape: return "invalid escape sequence";
+case error::token_not_number: return "token is not a number";
+case error::value_is_scalar: return "current value is scalar";
+case error::not_found: return "no referenced value";
+case error::token_overflow: return "token overflow";
+case error::past_the_end: return "past-the-end token not supported";
             }
         }
 
@@ -80,6 +88,17 @@ case error::exception:
 case error::not_number:
 case error::not_exact:
     return condition::assign_error;
+
+case error::missing_slash:
+case error::invalid_escape:
+    return condition::pointer_parse_error;
+
+case error::token_not_number:
+case error::value_is_scalar:
+case error::not_found:
+case error::token_overflow:
+case error::past_the_end:
+    return condition::pointer_use_error;
             }
         }
     };
@@ -112,6 +131,11 @@ make_error_condition(condition c)
                 return "A JSON parse error occurred";
             case condition::assign_error:
                 return "An error occurred during assignment";
+            case condition::pointer_parse_error:
+                return "A JSON Pointer parse error occurred";
+            case condition::pointer_use_error:
+                return "An error occurred when JSON Pointer was used with"
+                    " a value";
             }
         }
     };

--- a/include/boost/json/impl/object.hpp
+++ b/include/boost/json/impl/object.hpp
@@ -379,7 +379,7 @@ insert_or_assign(
         std::pair<iterator, bool>
 {
     reserve(size() + 1);
-    auto const result = find_impl(key);
+    auto const result = detail::find_in_object(*this, key);
     if(result.first)
     {
         value(std::forward<M>(m),
@@ -401,7 +401,7 @@ emplace(
         std::pair<iterator, bool>
 {
     reserve(size() + 1);
-    auto const result = find_impl(key);
+    auto const result = detail::find_in_object(*this, key);
     if(result.first)
         return { result.first, false };
     key_value_pair kv(key,

--- a/include/boost/json/impl/pointer.ipp
+++ b/include/boost/json/impl/pointer.ipp
@@ -1,0 +1,352 @@
+//
+// Copyright (c) 2022 Dmitry Arkhipov (grisumbras@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/json
+//
+
+#ifndef BOOST_JSON_IMPL_POINTER_IPP
+#define BOOST_JSON_IMPL_POINTER_IPP
+
+#include <boost/json/value.hpp>
+
+BOOST_JSON_NS_BEGIN
+
+namespace detail {
+
+class pointer_token
+{
+public:
+    class iterator;
+
+    pointer_token(
+        char const* b,
+        char const* e) noexcept
+        : b_(b)
+        , e_(e)
+    {
+    }
+
+    iterator begin() const noexcept;
+    iterator end() const noexcept;
+
+private:
+    char const* b_;
+    char const* e_;
+};
+
+class pointer_token::iterator
+{
+public:
+    explicit iterator(char const* base) noexcept
+        : base_(base)
+    {
+    }
+
+    char operator*() const noexcept
+    {
+        switch( char c = *base_ )
+        {
+        case '~':
+            c = base_[1];
+            if( '0' == c )
+                return '~';
+            BOOST_ASSERT('1' == c);
+            return '/';
+        default:
+            return c;
+        }
+    }
+
+    iterator& operator++() noexcept
+    {
+        if( '~' == *base_ )
+            base_ += 2;
+        else
+            ++base_;
+        return *this;
+    }
+
+    char const* base() const noexcept
+    {
+        return base_;
+    }
+
+private:
+    char const* base_;
+};
+
+bool operator==(pointer_token::iterator l, pointer_token::iterator r) noexcept
+{
+    return l.base() == r.base();
+}
+
+bool operator!=(pointer_token::iterator l, pointer_token::iterator r) noexcept
+{
+    return l.base() != r.base();
+}
+
+pointer_token::iterator pointer_token::begin() const noexcept
+{
+    return iterator(b_);
+}
+
+pointer_token::iterator pointer_token::end() const noexcept
+{
+    return iterator(e_);
+}
+
+bool operator==(pointer_token token, string_view sv) noexcept
+{
+    auto t_b = token.begin();
+    auto const t_e = token.end();
+    auto s_b = sv.begin();
+    auto const s_e = sv.end();
+    while( s_b != s_e )
+    {
+        if( t_e == t_b )
+            return false;
+        if( *t_b != *s_b )
+            return false;
+        ++t_b;
+        ++s_b;
+    }
+    return t_b == t_e;
+}
+
+bool is_invalid_zero(
+    char const* b,
+    char const* e) noexcept
+{
+    // in JSON Pointer only zero index can start character '0'
+    if( *b != '0' )
+        return false;
+
+    // if an index token starts with '0', then it should not have any more
+    // characters: either the string should end, or new token should start
+    ++b;
+    if( b == e )
+        return false;
+    return *b != '/';
+}
+
+bool is_past_the_end_token(
+    char const* b,
+    char const* e) noexcept
+{
+    if( *b != '-' )
+        return false;
+
+    ++b;
+    if( b == e )
+        return true;
+    return *b == '/';
+}
+
+std::size_t
+parse_number_token(
+    char const*& b,
+    char const* e,
+    error_code& ec) noexcept
+{
+    if( ( b == e )
+        || is_invalid_zero(b, e) )
+    {
+        BOOST_STATIC_CONSTEXPR source_location loc = BOOST_JSON_SOURCE_POS;
+        BOOST_JSON_ASSIGN_ERROR_CODE(ec, error::token_not_number, &loc);
+        return {};
+    }
+
+    if( is_past_the_end_token(b, e) )
+    {
+        BOOST_STATIC_CONSTEXPR source_location loc = BOOST_JSON_SOURCE_POS;
+        BOOST_JSON_ASSIGN_ERROR_CODE(ec, error::past_the_end, &loc);
+        return {};
+    }
+
+    std::size_t result = 0;
+    for( ; b != e; ++b )
+    {
+        char const c = *b;
+
+        if( '/' == c)
+            break;
+
+        unsigned d = c - '0';
+        if( d > 9 )
+        {
+            BOOST_STATIC_CONSTEXPR source_location loc = BOOST_JSON_SOURCE_POS;
+            BOOST_JSON_ASSIGN_ERROR_CODE(ec, error::token_not_number, &loc);
+            return {};
+        }
+
+        std::size_t new_result = result * 10 + d;
+        if( new_result < result )
+        {
+            BOOST_STATIC_CONSTEXPR source_location loc = BOOST_JSON_SOURCE_POS;
+            BOOST_JSON_ASSIGN_ERROR_CODE(ec, error::token_overflow, &loc);
+            return {};
+        }
+
+        result = new_result;
+
+    }
+    return result;
+}
+
+pointer_token
+get_token(
+    char const* b,
+    char const* e,
+    error_code& ec) noexcept
+{
+    char const* start = b;
+    for( ; b < e; ++b )
+    {
+        char const c = *b;
+        if( '/' == c )
+            break;
+
+        if( '~' == c )
+        {
+            if( ++b == e )
+            {
+                BOOST_STATIC_CONSTEXPR source_location loc
+                    = BOOST_JSON_SOURCE_POS;
+                BOOST_JSON_ASSIGN_ERROR_CODE(ec, error::invalid_escape, &loc);
+                break;
+            }
+
+            switch (*b)
+            {
+            case '0': // fall through
+            case '1':
+                // valid escape sequence
+                continue;
+            default: {
+                BOOST_STATIC_CONSTEXPR source_location loc
+                    = BOOST_JSON_SOURCE_POS;
+                BOOST_JSON_ASSIGN_ERROR_CODE(ec, error::invalid_escape, &loc);
+                break;
+            }
+            }
+            break;
+        }
+    }
+
+    return pointer_token(start, b);
+}
+
+value*
+if_contains_token(object const& obj, pointer_token token)
+{
+    if( obj.empty() )
+        return nullptr;
+
+    auto const it = detail::find_in_object(obj, token).first;
+    if( !it )
+        return nullptr;
+
+    return &it->value();
+}
+
+} // namespace detail
+
+value const&
+value::at_pointer(string_view ptr) const
+{
+    error_code ec;
+    auto const found = find_pointer(ptr, ec);
+    if( !found )
+        detail::throw_system_error(ec, BOOST_JSON_SOURCE_POS);
+    return *found;
+}
+
+value&
+value::at_pointer(string_view ptr)
+{
+    value const& self = *this;
+    return const_cast<value&>(self.at_pointer(ptr));
+}
+
+value const*
+value::find_pointer(string_view ptr, error_code& ec) const noexcept
+{
+    ec.clear();
+
+    value const* result = this;
+    char const* cur = ptr.data();
+    char const* const end = cur + ptr.size();
+    while( end != cur )
+    {
+        if( *cur++ != '/' )
+        {
+            BOOST_STATIC_CONSTEXPR source_location loc = BOOST_JSON_SOURCE_POS;
+            BOOST_JSON_ASSIGN_ERROR_CODE(ec, error::missing_slash, &loc);
+            return nullptr;
+        }
+
+        if( auto const po = result->if_object() )
+        {
+            auto const token = detail::get_token(cur, end, ec);
+            if( ec )
+                return nullptr;
+
+            result = detail::if_contains_token(*po, token);
+            cur = token.end().base();
+        }
+        else if( auto const pa = result->if_array() )
+        {
+            auto const index = detail::parse_number_token(cur, end, ec);
+            if( ec )
+                return nullptr;
+
+            result = pa->if_contains(index);
+        }
+        else
+        {
+            BOOST_STATIC_CONSTEXPR source_location loc = BOOST_JSON_SOURCE_POS;
+            BOOST_JSON_ASSIGN_ERROR_CODE(ec, error::value_is_scalar, &loc);
+            return nullptr;
+        }
+
+        if( !result )
+        {
+            BOOST_STATIC_CONSTEXPR source_location loc = BOOST_JSON_SOURCE_POS;
+            BOOST_JSON_ASSIGN_ERROR_CODE(ec, error::not_found, &loc);
+            return nullptr;
+        }
+    }
+
+    BOOST_ASSERT(result);
+    return result;
+}
+
+value*
+value::find_pointer(string_view ptr, error_code& ec) noexcept
+{
+    value const& self = *this;
+    return const_cast<value*>(self.find_pointer(ptr, ec));
+}
+
+value const*
+value::find_pointer(string_view ptr, std::error_code& ec) const noexcept
+{
+    error_code jec;
+    value const* result = find_pointer(ptr, jec);
+    ec = jec;
+    return result;
+}
+
+value*
+value::find_pointer(string_view ptr, std::error_code& ec) noexcept
+{
+    value const& self = *this;
+    return const_cast<value*>(self.find_pointer(ptr, ec));
+}
+
+BOOST_JSON_NS_END
+
+#endif // BOOST_JSON_IMPL_POINTER_IPP

--- a/include/boost/json/object.hpp
+++ b/include/boost/json/object.hpp
@@ -1483,39 +1483,42 @@ public:
     }
 
 private:
-    template<class InputIt>
-    void
-    construct(
-        InputIt first,
-        InputIt last,
-        std::size_t min_capacity,
-        std::input_iterator_tag);
-
-    template<class InputIt>
-    void
-    construct(
-        InputIt first,
-        InputIt last,
-        std::size_t min_capacity,
-        std::forward_iterator_tag);
-
-    template<class InputIt>
-    void
-    insert(
-        InputIt first,
-        InputIt last,
-        std::input_iterator_tag);
-
-    template<class InputIt>
-    void
-    insert(
-        InputIt first,
-        InputIt last,
-        std::forward_iterator_tag);
-
-    BOOST_JSON_DECL
+    template<class CharRange>
+    friend
     std::pair<key_value_pair*, std::size_t>
-    find_impl(string_view key) const noexcept;
+    detail::find_in_object(
+        object const& obj,
+        CharRange key) noexcept;
+
+    template<class InputIt>
+    void
+    construct(
+        InputIt first,
+        InputIt last,
+        std::size_t min_capacity,
+        std::input_iterator_tag);
+
+    template<class InputIt>
+    void
+    construct(
+        InputIt first,
+        InputIt last,
+        std::size_t min_capacity,
+        std::forward_iterator_tag);
+
+    template<class InputIt>
+    void
+    insert(
+        InputIt first,
+        InputIt last,
+        std::input_iterator_tag);
+
+    template<class InputIt>
+    void
+    insert(
+        InputIt first,
+        InputIt last,
+        std::forward_iterator_tag);
 
     BOOST_JSON_DECL
     std::pair<iterator, bool>

--- a/include/boost/json/src.hpp
+++ b/include/boost/json/src.hpp
@@ -36,6 +36,7 @@ in a translation unit of the program.
 #include <boost/json/impl/object.ipp>
 #include <boost/json/impl/parse.ipp>
 #include <boost/json/impl/parser.ipp>
+#include <boost/json/impl/pointer.ipp>
 #include <boost/json/impl/serialize.ipp>
 #include <boost/json/impl/serializer.ipp>
 #include <boost/json/impl/static_resource.ipp>

--- a/include/boost/json/string.hpp
+++ b/include/boost/json/string.hpp
@@ -2918,7 +2918,7 @@ struct hash< ::boost::json::string >
     operator()(::boost::json::string const& js) const noexcept
     {
         return ::boost::json::detail::digest(
-            js.data(), js.size(), salt_);
+            js.begin(), js.end(), salt_);
     }
 
 private:

--- a/include/boost/json/value.hpp
+++ b/include/boost/json/value.hpp
@@ -3208,6 +3208,76 @@ public:
         return as_array().at(pos);
     }
 
+    /** Access an element via JSON Pointer.
+
+        This function is used to access a (potentially nested)
+        element of the value using a JSON Pointer string.
+
+        @par Complexity
+        Linear in the sizes of `ptr` and underlying array, object, or string.
+
+        @par Exception Safety
+        Strong guarantee.
+
+        @param ptr JSON Pointer string.
+
+        @return reference to the element identified by `ptr`.
+
+        @throw system_error if an error occurs.
+
+        @see
+        <a href="https://datatracker.ietf.org/doc/html/rfc6901">
+            RFC 6901 - JavaScript Object Notation (JSON) Pointer</a>
+    */
+/** @{ */
+    BOOST_JSON_DECL
+    value const&
+    at_pointer(string_view ptr) const;
+
+    BOOST_JSON_DECL
+    value&
+    at_pointer(string_view ptr);
+/** @} */
+
+    /** Access an element via JSON Pointer.
+
+        This function is used to access a (potentially nested)
+        element of the value using a JSON Pointer string.
+
+        @par Complexity
+        Linear in the sizes of `ptr` and underlying array, object, or string.
+
+        @par Exception Safety
+        No-throw guarantee.
+
+        @param ptr JSON Pointer string.
+
+        @param ec Set to the error, if any occurred.
+
+        @return pointer to the element identified by `ptr`.
+
+        @see
+        <a href="https://datatracker.ietf.org/doc/html/rfc6901">
+            RFC 6901 - JavaScript Object Notation (JSON) Pointer</a>
+    */
+/** @{ */
+    BOOST_JSON_DECL
+    value const*
+    find_pointer(string_view ptr, error_code& ec) const noexcept;
+
+    BOOST_JSON_DECL
+    value*
+    find_pointer(string_view ptr, error_code& ec) noexcept;
+
+    BOOST_JSON_DECL
+    value const*
+    find_pointer(string_view ptr, std::error_code& ec) const noexcept;
+
+    BOOST_JSON_DECL
+    value*
+    find_pointer(string_view ptr, std::error_code& ec) noexcept;
+/** @} */
+
     /** Return `true` if two values are equal.
 
         Two values are equal when they are the

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -33,6 +33,7 @@ local SOURCES =
     parse.cpp
     parser.cpp
     pilfer.cpp
+    pointer.cpp
     serialize.cpp
     serializer.cpp
     snippets.cpp

--- a/test/error.cpp
+++ b/test/error.cpp
@@ -65,6 +65,15 @@ public:
         check(condition::assign_error, error::not_number);
         check(condition::assign_error, error::not_exact);
 
+        check(condition::pointer_parse_error, error::missing_slash);
+        check(condition::pointer_parse_error, error::invalid_escape);
+
+        check(condition::pointer_use_error, error::token_not_number);
+        check(condition::pointer_use_error, error::value_is_scalar);
+        check(condition::pointer_use_error, error::not_found);
+        check(condition::pointer_use_error, error::token_overflow);
+        check(condition::pointer_use_error, error::past_the_end);
+
         check(error::test_failure);
 
         // check std interop

--- a/test/pointer.cpp
+++ b/test/pointer.cpp
@@ -1,0 +1,248 @@
+//
+// Copyright (c) 2022 Dmitry Arkhipov (grisumbras@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/json
+//
+
+#include <boost/json/value.hpp>
+
+#include "test_suite.hpp"
+
+BOOST_JSON_NS_BEGIN
+
+
+class pointer_test
+{
+    bool
+    hasLocation(error_code const& ec)
+    {
+        return ec.has_location();
+    }
+
+    bool
+    hasLocation(std::error_code const&)
+    {
+        return true;
+    }
+
+    value
+    testValue() const
+    {
+        return value{
+            {"foo", {"bar", "baz", "baf"}},
+            {"", 0},
+            {"a/b", 1},
+            {"c%d", 2},
+            {"e^f", 3},
+            {"g|h", 4},
+            {"i\\j", 5},
+            {"k\"l", 6},
+            {" ", 7},
+            {"m~n", 8},
+            {"x", object{{"y", "z"}}},
+        };
+    }
+
+    value
+    bigObject() const
+    {
+        object result;
+        for (int i = 0; i < 50; ++i)
+        {
+            result.emplace(std::to_string(i), i);
+        }
+        return result;
+    }
+
+public:
+    void
+    testRootPointer()
+    {
+        value const jv = testValue();
+        BOOST_TEST(&jv.at_pointer("") == &jv);
+    }
+
+    void
+    testChildPointer()
+    {
+        value const jv = testValue();
+        BOOST_TEST(&jv.at_pointer("/foo")== &jv.at("foo"));
+        BOOST_TEST(&jv.at_pointer("/c%d")== &jv.at("c%d"));
+        BOOST_TEST(&jv.at_pointer("/e^f")== &jv.at("e^f"));
+        BOOST_TEST(&jv.at_pointer("/g|h")== &jv.at("g|h"));
+        BOOST_TEST(&jv.at_pointer("/")== &jv.at(""));
+        BOOST_TEST(&jv.at_pointer("/i\\j")== &jv.at("i\\j"));
+        BOOST_TEST(&jv.at_pointer("/k\"l")== &jv.at("k\"l"));
+        BOOST_TEST(&jv.at_pointer("/ ")== &jv.at(" "));
+    }
+
+    void
+    testEscaped()
+    {
+        value const jv = testValue();
+        BOOST_TEST(&jv.at_pointer("/a~1b")== &jv.at("a/b"));
+        BOOST_TEST(&jv.at_pointer("/m~0n")== &jv.at("m~n"));
+    }
+
+    void
+    testNested()
+    {
+        value const jv = testValue();
+        BOOST_TEST(&jv.at_pointer("/foo/0") == &jv.at("foo").at(0));
+        BOOST_TEST(&jv.at_pointer("/foo/1") == &jv.at("foo").at(1));
+        BOOST_TEST(&jv.at_pointer("/x/y") == &jv.at("x").at("y"));
+
+        {
+            value v1;
+            object& o1 = v1.emplace_object();
+            object& o2 = (o1["very"] = value()).emplace_object();
+            object& o3 = (o2["deep"] = value()).emplace_object();
+
+            array& a1 = (o3["path"] = value()).emplace_array();
+            a1.emplace_back(value());
+
+            array& a2 = a1.emplace_back(value()).emplace_array();
+            a2.emplace_back(value());
+            a2.emplace_back(value());
+
+            array& a3 = a2.emplace_back(value()).emplace_array();
+            object& o4 = a3.emplace_back(value()).emplace_object();
+            object& o5 = (o4["0"] = value()).emplace_object();
+            value& v2 = o5["fin"] = value();
+
+            BOOST_TEST(&v1.at_pointer("/very/deep/path/1/2/0/0/fin") == &v2);
+        }
+    }
+
+    void
+    testErrors()
+    {
+        value const jv = testValue();
+        BOOST_TEST_THROWS(jv.at_pointer("foo"), system_error);
+        BOOST_TEST_THROWS(jv.at_pointer("/fo"), system_error);
+        BOOST_TEST_THROWS(jv.at_pointer("/m~"), system_error);
+        BOOST_TEST_THROWS(jv.at_pointer("/m~n"), system_error);
+        BOOST_TEST_THROWS(jv.at_pointer("/foo/bar"), system_error);
+        BOOST_TEST_THROWS(jv.at_pointer("/foo/"), system_error);
+        BOOST_TEST_THROWS(jv.at_pointer("/foo/01"), system_error);
+        BOOST_TEST_THROWS(jv.at_pointer("/foo/2b"), system_error);
+        BOOST_TEST_THROWS(jv.at_pointer("/x/y/z"), system_error);
+    }
+
+    template<class ErrorCode>
+    void
+    testNonThrowing()
+    {
+        value jv = testValue();
+        ErrorCode ec = error::syntax;
+        BOOST_TEST(jv.find_pointer("/foo/0", ec) == &jv.at("foo").at(0));
+        BOOST_TEST(!ec);
+
+        auto const& cjv = jv;
+        ec = error::syntax;
+        BOOST_TEST(cjv.find_pointer("/foo/1", ec) == &jv.at("foo").at(1));
+        BOOST_TEST(!ec);
+
+        jv.find_pointer("foo", ec);
+        BOOST_TEST(ec == error::missing_slash);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/fo", ec);
+        BOOST_TEST(ec == error::not_found);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/foo/25", ec);
+        BOOST_TEST(ec == error::not_found);
+        BOOST_TEST(hasLocation(ec));
+
+        value(object()).find_pointer("/foo", ec);
+        BOOST_TEST(ec == error::not_found);
+        BOOST_TEST(hasLocation(ec));
+
+        bigObject().find_pointer("/foo", ec);
+        BOOST_TEST(ec == error::not_found);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/m~", ec);
+        BOOST_TEST(ec == error::invalid_escape);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/m~n", ec);
+        BOOST_TEST(ec == error::invalid_escape);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/foo/bar", ec);
+        BOOST_TEST(ec == error::token_not_number);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/foo/", ec);
+        BOOST_TEST(ec == error::token_not_number);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/foo/01", ec);
+        BOOST_TEST(ec == error::token_not_number);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/foo/2b", ec);
+        BOOST_TEST(ec == error::token_not_number);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/foo/2.", ec);
+        BOOST_TEST(ec == error::token_not_number);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/foo/-", ec);
+        BOOST_TEST(ec == error::past_the_end);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/foo/-/x", ec);
+        BOOST_TEST(ec == error::past_the_end);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/foo/-1", ec);
+        BOOST_TEST(ec == error::token_not_number);
+        BOOST_TEST(hasLocation(ec));
+
+        jv.find_pointer("/x/y/z", ec);
+        BOOST_TEST(ec == error::value_is_scalar);
+        BOOST_TEST(hasLocation(ec));
+
+        string s = "/foo/";
+        s += std::to_string((std::numeric_limits<std::size_t>::max)());
+        if ( '9' == s[s.size() - 1] )
+        {
+            for (std::size_t i = 6; i < s.size(); ++i)
+            {
+                s[i] = '0';
+            }
+            s[5] = '1';
+            s += "0";
+        }
+        else
+        {
+            ++s[s.size() - 1];
+        }
+        jv.find_pointer(s, ec);
+        BOOST_TEST(ec == error::token_overflow);
+        BOOST_TEST(hasLocation(ec));
+    }
+
+    void
+    run()
+    {
+        testRootPointer();
+        testChildPointer();
+        testEscaped();
+        testNested();
+        testErrors();
+        testNonThrowing<error_code>();
+        testNonThrowing<std::error_code>();
+    }
+};
+
+TEST_SUITE(pointer_test, "boost.json.pointer");
+
+BOOST_JSON_NS_END

--- a/test/snippets.cpp
+++ b/test/snippets.cpp
@@ -781,6 +781,60 @@ usingExchange()
     }
 }
 
+void
+usingPointer()
+{
+    //[snippet_pointer_1
+    value jv = { {"one", 1}, {"two", 2} };
+    assert( jv.at("one") == jv.at_pointer("/one") );
+
+    jv.at_pointer("/one") = {{"foo", "bar"}};
+    assert( jv.at("one").at("foo") == jv.at_pointer("/one/foo") );
+
+    jv.at_pointer("/one/foo") = {true, 4, "qwerty"};
+    assert( jv.at("one").at("foo").at(1) == jv.at_pointer("/one/foo/1") );
+    //]
+
+    value* elem1 = [&]() -> value*
+    {
+        //[snippet_pointer_2
+        object* obj = jv.if_object();
+        if( !obj )
+            return nullptr;
+
+        value* val = obj->if_contains("one");
+        if( !val )
+            return nullptr;
+
+        obj = val->if_object();
+        if( !obj )
+            return nullptr;
+
+        val = obj->if_contains("foo");
+        if( !val )
+            return nullptr;
+
+        array* arr = val->if_array();
+        if( !arr )
+            return nullptr;
+
+        return arr->if_contains(1);
+        //]
+    }();
+
+    value* elem2 = [&]() -> value*
+    {
+        //[snippet_pointer_3
+        error_code ec;
+        return jv.find_pointer("/one/foo/1", ec);
+        //]
+    }();
+
+    (void)elem1;
+    (void)elem2;
+    assert( elem1 == elem2 );
+}
+
 BOOST_STATIC_ASSERT(
     has_value_from<customer>::value);
 
@@ -838,6 +892,7 @@ public:
         usingArrays();
         usingObjects();
         usingStrings();
+        usingPointer();
 
         BOOST_TEST_PASS();
     }


### PR DESCRIPTION
* Class `pointer` in `boost/json/pointer.hpp`; stores a `string_view` that should contain a JSON Pointer string.
* Member function `value& value::at(pointer)` that either returns a reference to corresponding child or throws `system_error`.
* Member function `value* value::find(pointer, error_code&)` that either returns a pointer to corresponding child or sets `error_code` to some error.
* `const` versions of those functions.
* Extend `error` and `error_condition` enums with values needed for Pointer.