### PR TITLE
Update appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 # Copyright 2016, 2017 Peter Dimov
 # Copyright 2017 - 2019 James E. King III
-# Copyright 2020 Alexander Grund
+# Copyright 2019 - 2021 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
@@ -22,7 +22,7 @@
 
 version: 1.0.{build}-{branch}
 
-shallow_clone: true
+shallow_clone: false
 
 branches:
   only:
@@ -34,6 +34,7 @@ branches:
     - /pr\/.*/
 
 matrix:
+  fast_finish: false
   # Adding MAYFAIL to any matrix job allows it to fail but the build stays green:
   allow_failures:
     - MAYFAIL: true
@@ -41,6 +42,7 @@ matrix:
 environment:
   global:
     B2_CI_VERSION: 1
+    GIT_FETCH_JOBS: 4
     # see: http://www.boost.org/build/doc/html/bbv2/overview/invocation.html#bbv2.overview.invocation.properties
     # to use the default for a given environment, comment it out; recommend you build debug and release however:
     # on Windows it is important to exercise all the possibilities, especially shared vs static, however most
@@ -49,41 +51,24 @@ environment:
     B2_LINK: shared,static
     # B2_THREADING: threading=multi,single
     B2_VARIANT: release
-    B2_FLAGS: "warnings=extra warnings-as-errors=on"
 
   matrix:
-    - FLAVOR: clang-cl
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 11,14,17
-      B2_TOOLSET: clang-win
-
-    - FLAVOR: cygwin (64-bit)
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      ADDPATH: C:\cygwin64\bin;
-      B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 11,14,1z
-      B2_THREADING: threadapi=pthread
-      B2_TOOLSET: gcc
-
-    - FLAVOR: mingw32
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      ARCH: i686
-      B2_ADDRESS_MODEL: 32
-      B2_CXXSTD: 11
-      SCRIPT: ci\appveyor\mingw.bat
-      B2_VARIANT: debug
+    - FLAVOR: Visual Studio 2022
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      B2_CXXFLAGS: -permissive-
+      B2_CXXSTD: 14,17,20
+      B2_TOOLSET: msvc-14.3
 
     - FLAVOR: Visual Studio 2019
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       B2_CXXFLAGS: -permissive-
-      B2_CXXSTD: 14,17,latest # 2a
+      B2_CXXSTD: 14,17,2a
       B2_TOOLSET: msvc-14.2
 
     - FLAVOR: Visual Studio 2017 C++2a Strict
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       B2_CXXFLAGS: -permissive-
-      B2_CXXSTD: latest # 2a
+      B2_CXXSTD: 2a
       B2_TOOLSET: msvc-14.1
 
     - FLAVOR: Visual Studio 2017 C++14/17
@@ -91,26 +76,56 @@ environment:
       B2_CXXSTD: 14,17
       B2_TOOLSET: msvc-14.1
 
+    - FLAVOR: clang-cl
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ADDCOMMANDS: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"'
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 11,14,17
+      B2_TOOLSET: clang-win
+
+    # not supported
+    # - FLAVOR: Visual Studio 2015, 2013
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   B2_TOOLSET: msvc-12.0,msvc-14.0
+
+    # - FLAVOR: Visual Studio 2008, 2010, 2012
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #   B2_TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0
+    #   B2_ADDRESS_MODEL: 32 # No 64bit support
+
     - FLAVOR: cygwin (32-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ADDPATH: C:\cygwin\bin;
       B2_ADDRESS_MODEL: 32
       B2_CXXSTD: 11,14,1z
-      B2_THREADING: threadapi=pthread
+      B2_TOOLSET: gcc
+
+    - FLAVOR: cygwin (64-bit)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ADDPATH: C:\cygwin64\bin;
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 11,14,1z
+      B2_TOOLSET: gcc
+
+    - FLAVOR: mingw32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      B2_ADDRESS_MODEL: 32
+      ADDPATH: C:\mingw\bin;
+      B2_CXXSTD: 11,14,17,2a
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      ARCH: x86_64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      ADDPATH: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;
       B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 11,17
-      B2_DEFINES: __USE_ISOC99
-      SCRIPT: ci\appveyor\mingw.bat
+      B2_CXXSTD: 11,14,17,2a
+      B2_TOOLSET: gcc
 
 install:
-  #- git submodule update --init --recursive
-  - git clone https://github.com/boostorg/boost-ci.git C:\boost-ci-cloned
-  - xcopy /s /e /q /i /y C:\boost-ci-cloned\ci .\ci
+  - '%ADDCOMMANDS%'
+  - git clone --depth 1 https://github.com/boostorg/boost-ci.git C:\boost-ci-cloned
+  # Copy ci folder if not testing Boost.CI
+  - if NOT "%APPVEYOR_PROJECT_NAME%" == "boost-ci" xcopy /s /e /q /i /y C:\boost-ci-cloned\ci .\ci
   - rmdir /s /q C:\boost-ci-cloned
   - ci\appveyor\install.bat
 


### PR DESCRIPTION
A newer copy of .appveyor.yml.   Appveyor hasn't been running on boostorg/json recently?  This could be re-enabled, using the 'cppalliance' account at appveyor, I will send invites to grisumbras and vinniefalco so you can login and add repositories.     
In the meantime, a fork of the repo demonstrates a few errors are appearing:  https://ci.appveyor.com/project/cppalliance/json-test 

