### PR TITLE
Move definitions of several std::error_code overloads out of line

### DIFF
--- a/include/boost/json/impl/parse.ipp
+++ b/include/boost/json/impl/parse.ipp
@@ -37,6 +37,19 @@ parse(
 value
 parse(
     string_view s,
+    std::error_code& ec,
+    storage_ptr sp,
+    parse_options const& opt)
+{
+    error_code jec;
+    value result = parse(s, jec, std::move(sp), opt);
+    ec = jec;
+    return result;
+}
+
+value
+parse(
+    string_view s,
     storage_ptr sp,
     const parse_options& opt)
 {

--- a/include/boost/json/impl/parser.ipp
+++ b/include/boost/json/impl/parser.ipp
@@ -72,6 +72,19 @@ std::size_t
 parser::
 write_some(
     char const* data,
+    std::size_t size,
+    std::error_code& ec)
+{
+    error_code jec;
+    std::size_t const result = write_some(data, size, jec);
+    ec = jec;
+    return result;
+}
+
+std::size_t
+parser::
+write_some(
+    char const* data,
     std::size_t size)
 {
     error_code ec;
@@ -99,6 +112,19 @@ write(
         p_.fail(ec);
     }
     return n;
+}
+
+std::size_t
+parser::
+write(
+    char const* data,
+    std::size_t size,
+    std::error_code& ec)
+{
+    error_code jec;
+    std::size_t const result = write(data, size, jec);
+    ec = jec;
+    return result;
 }
 
 std::size_t

--- a/include/boost/json/impl/stream_parser.ipp
+++ b/include/boost/json/impl/stream_parser.ipp
@@ -70,6 +70,19 @@ std::size_t
 stream_parser::
 write_some(
     char const* data,
+    std::size_t size,
+    std::error_code& ec)
+{
+    error_code jec;
+    std::size_t const result = write_some(data, size, jec);
+    ec = jec;
+    return result;
+}
+
+std::size_t
+stream_parser::
+write_some(
+    char const* data,
     std::size_t size)
 {
     error_code ec;
@@ -103,6 +116,19 @@ std::size_t
 stream_parser::
 write(
     char const* data,
+    std::size_t size,
+    std::error_code& ec)
+{
+    error_code jec;
+    std::size_t const result = write(data, size, jec);
+    ec = jec;
+    return result;
+}
+
+std::size_t
+stream_parser::
+write(
+    char const* data,
     std::size_t size)
 {
     error_code ec;
@@ -130,6 +156,15 @@ finish()
     if(ec)
         detail::throw_system_error(ec,
             BOOST_JSON_SOURCE_POS);
+}
+
+void
+stream_parser::
+finish(std::error_code& ec)
+{
+    error_code jec;
+    finish(jec);
+    ec = jec;
 }
 
 value

--- a/include/boost/json/parse.hpp
+++ b/include/boost/json/parse.hpp
@@ -63,19 +63,13 @@ parse(
     storage_ptr sp = {},
     parse_options const& opt = {});
 
-inline
+BOOST_JSON_DECL
 value
 parse(
     string_view s,
     std::error_code& ec,
     storage_ptr sp = {},
-    parse_options const& opt = {})
-{
-    error_code jec;
-    value result = parse(s, jec, std::move(sp), opt);
-    ec = jec;
-    return result;
-}
+    parse_options const& opt = {});
 /** @} */
 
 /** Parse a string of JSON into a @ref value.

--- a/include/boost/json/parser.hpp
+++ b/include/boost/json/parser.hpp
@@ -469,13 +469,7 @@ public:
     write_some(
         char const* data,
         std::size_t size,
-        std::error_code& ec)
-    {
-        error_code jec;
-        std::size_t const result = write_some(data, size, jec);
-        ec = jec;
-        return result;
-    }
+        std::error_code& ec);
 /** @} */
 
     /** Parse a buffer containing a complete JSON.
@@ -665,17 +659,12 @@ public:
         std::size_t size,
         error_code& ec);
 
+    BOOST_JSON_DECL
     std::size_t
     write(
         char const* data,
         std::size_t size,
-        std::error_code& ec)
-    {
-        error_code jec;
-        std::size_t const result = write(data, size, jec);
-        ec = jec;
-        return result;
-    }
+        std::error_code& ec);
 /** @} */
 
     /** Parse a buffer containing a complete JSON.

--- a/include/boost/json/stream_parser.hpp
+++ b/include/boost/json/stream_parser.hpp
@@ -518,17 +518,12 @@ public:
         std::size_t size,
         error_code& ec);
 
+    BOOST_JSON_DECL
     std::size_t
     write_some(
         char const* data,
         std::size_t size,
-        std::error_code& ec)
-    {
-        error_code jec;
-        std::size_t const result = write_some(data, size, jec);
-        ec = jec;
-        return result;
-    }
+        std::error_code& ec);
 /** @} */
 
     /** Parse a buffer containing all or part of a complete JSON.
@@ -754,17 +749,12 @@ public:
         std::size_t size,
         error_code& ec);
 
+    BOOST_JSON_DECL
     std::size_t
     write(
         char const* data,
         std::size_t size,
-        std::error_code& ec)
-    {
-        error_code jec;
-        std::size_t const result = write(data, size, jec);
-        ec = jec;
-        return result;
-    }
+        std::error_code& ec);
 /** @} */
 
     /** Parse a buffer containing all or part of a complete JSON.
@@ -966,13 +956,9 @@ public:
     void
     finish(error_code& ec);
 
+    BOOST_JSON_DECL
     void
-    finish(std::error_code& ec)
-    {
-        error_code jec;
-        finish(jec);
-        ec = jec;
-    }
+    finish(std::error_code& ec);
 /** @} */
 
     /** Indicate the end of JSON input.


### PR DESCRIPTION
Fix #682 