### PR TITLE
Refactoring of conversion functions

### DIFF
--- a/doc/qbk/quickref.xml
+++ b/doc/qbk/quickref.xml
@@ -58,6 +58,7 @@
           <member><link linkend="json.ref.boost__json__is_string_like">is_string_like</link></member>
           <member><link linkend="json.ref.boost__json__is_sequence_like">is_sequence_like</link></member>
           <member><link linkend="json.ref.boost__json__is_map_like">is_map_like</link></member>
+          <member><link linkend="json.ref.boost__json__is_null_like">is_null_like</link></member>
           <member><link linkend="json.ref.boost__json__is_tuple_like">is_tuple_like</link></member>
           <member><link linkend="json.ref.boost__json__value_from_tag">value_from_tag</link></member>
           <member><link linkend="json.ref.boost__json__value_to_tag">value_to_tag</link></member>

--- a/doc/qbk/quickref.xml
+++ b/doc/qbk/quickref.xml
@@ -55,6 +55,10 @@
           <member><link linkend="json.ref.boost__json__has_value_from">has_value_from</link></member>
           <member><link linkend="json.ref.boost__json__has_value_to">has_value_to</link></member>
           <member><link linkend="json.ref.boost__json__is_deallocate_trivial">is_deallocate_trivial</link></member>
+          <member><link linkend="json.ref.boost__json__is_string_like">is_string_like</link></member>
+          <member><link linkend="json.ref.boost__json__is_sequence_like">is_sequence_like</link></member>
+          <member><link linkend="json.ref.boost__json__is_map_like">is_map_like</link></member>
+          <member><link linkend="json.ref.boost__json__is_tuple_like">is_tuple_like</link></member>
           <member><link linkend="json.ref.boost__json__value_from_tag">value_from_tag</link></member>
           <member><link linkend="json.ref.boost__json__value_to_tag">value_to_tag</link></member>
         </simplelist>

--- a/include/boost/json/conversion.hpp
+++ b/include/boost/json/conversion.hpp
@@ -1,0 +1,259 @@
+//
+// Copyright (c) 2022 Dmitry Arkhipov (grisumbras@yandex.ru)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/json
+//
+
+#ifndef BOOST_JSON_CONVERSION_HPP
+#define BOOST_JSON_CONVERSION_HPP
+
+#include <boost/json/string_view.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/utility.hpp>
+
+#include <utility>
+
+BOOST_JSON_NS_BEGIN
+namespace detail {
+
+using std::begin;
+using std::end;
+
+template<std::size_t I, class T>
+using tuple_element_t = typename std::tuple_element<I, T>::type;
+
+template<class T>
+using value_type = remove_cvref< decltype(*begin(std::declval<T&>())) >;
+template<class T>
+using mapped_type = tuple_element_t< 1, value_type<T> >;
+
+// had to make the metafunction always succeeding in order to make it work
+// with msvc 14.0
+template<class T>
+using key_type_helper = tuple_element_t< 0, value_type<T> >;
+template<class T>
+using key_type = mp11::mp_eval_or<
+    void,
+    key_type_helper,
+    T>;
+
+template<class T>
+using are_begin_and_end_same = std::is_same<
+    decltype(begin(std::declval<T&>())),
+    decltype(end(std::declval<T&>()))>;
+
+template<class T>
+using has_positive_tuple_size = mp11::mp_bool<
+    (std::tuple_size<T>::value > 0) >;
+
+template<class T>
+using has_unique_keys = has_positive_tuple_size<decltype(
+    std::declval<T&>().emplace(
+        std::declval<value_type<T>>()))>;
+
+template<class T>
+using is_value_type_pair
+    = mp11::mp_bool<std::tuple_size<value_type<T>>::value == 2>;
+
+} // namespace detail
+
+/** Determine if `T` can be treated like a string during conversions.
+
+    Provides the member constant `value` that is equal to `true`, if `T` is
+    convertible to @ref string_view. Otherwise, `value` is equal to `false`.
+    <br>
+
+    Users can specialize the trait for their own types if they don't want them
+    to be treated like strings. For example:
+
+    @code
+    namespace boost {
+    namespace json {
+
+    template <>
+    struct is_string_like<your::string> : std::false_type
+    { };
+
+    } // namespace boost
+    } // namespace json
+    @endcode
+
+    @par Types satisfying the trait
+
+    @ref string,
+    @ref string_view,
+    <a href="https://en.cppreference.com/w/cpp/string/basic_string"><tt>std::string</tt></a>,
+    <a href="https://en.cppreference.com/w/cpp/string/basic_string_view"><tt>std::string_view</tt></a>.
+
+    @see @ref value_from, @ref value_to
+*/
+template<class T, class Enable = void>
+struct is_string_like
+#ifndef BOOST_JSON_DOCS
+    : std::is_convertible<T, string_view>
+{ };
+#else
+;
+#endif
+
+/** Determine if `T` can be treated like a sequence during conversions.
+
+    Given `t`, a glvalue of type `T`, if
+    <tt>std::is_same<decltype(BEGIN(t)), decltype(END(t))>::value</tt> is
+    well-formed and `true`, then the trait provides the member constant `value`
+    that is equal to `true`. Otherwise, `value` is equal to `false`.<br>
+
+    Operation `BEGIN(t)` is equivalent to
+
+    @code
+    using std::begin;
+    begin(t);
+    @endcode
+
+    Operation `END(t)` is equivalent to
+
+    @code
+    using std::end;
+    end(t);
+    @endcode
+
+    Users can specialize the trait for their own types if they don't want them
+    to be treated like sequences. For example:
+
+    @code
+    namespace boost {
+    namespace json {
+
+    template <>
+    struct is_sequence_like<your::container> : std::false_type
+    { };
+
+    } // namespace boost
+    } // namespace json
+    @endcode
+
+
+    @par Types satisfying the trait
+
+    Any <a href="https://en.cppreference.com/w/cpp/named_req/SequenceContainer"><em>SequenceContainer</em></a>,
+    array types.
+
+    @see @ref value_from, @ref value_to
+*/
+template<class T, class Enable = void>
+struct is_sequence_like
+#ifndef BOOST_JSON_DOCS
+    : mp11::mp_valid_and_true<detail::are_begin_and_end_same, T>
+{ };
+#else
+;
+#endif
+
+/** Determine if `T` can be treated like a 1-to-1 mapping during
+    conversions.
+
+    Given `t`, a glvalue of type `T`, if
+
+    @li <tt>is_sequence_like<T>::value</tt> is `true`; and
+
+    @li given `V`, the type denoted by
+        `std::remove_cvref_t<decltype(*BEGIN(t))>`,
+        <tt>std::tuple_size<V>::value</tt> is equal to 2; and
+
+    @li given `K`, the type denoted by `std::tuple_element_t<0, V>`,
+        <tt>std::is_string_like<K>::value</tt> is `true`; and
+
+    @li given `v`, a glvalue of type `V`, and `E`, the type denoted by
+        `decltype(t.emplace(v))`,
+        <tt>std::is_tuple_like<E>::value</tt> is `true`;
+
+    then the trait provides the member constant `value`
+    that is equal to `true`. Otherwise, `value` is equal to `false`.<br>
+
+    Operation `BEGIN(t)` is equivalent to
+
+    @code
+    using std::begin;
+    begin(t);
+    @endcode
+
+    Users can specialize the trait for their own types if they don't want them
+    to be treated like mappings. For example:
+
+    @code
+    namespace boost {
+    namespace json {
+
+    template <>
+    struct is_map_like<your::map> : std::false_type
+    { };
+
+    } // namespace boost
+    } // namespace json
+    @endcode
+
+
+    @par Types satisfying the trait
+
+    <a href="https://en.cppreference.com/w/cpp/container/map"><tt>std::map</tt></a>,
+    <a href="https://en.cppreference.com/w/cpp/container/unordered_map"><tt>std::unordered_map</tt></a>.
+
+    @see @ref value_from, @ref value_to
+*/
+template<class T, class Enable = void>
+struct is_map_like
+#ifndef BOOST_JSON_DOCS
+    : mp11::mp_all<
+        is_sequence_like<T>,
+        is_string_like<detail::key_type<T>>,
+        mp11::mp_valid_and_true<detail::has_unique_keys, T>,
+        mp11::mp_valid_and_true<detail::is_value_type_pair, T>>
+{ };
+#else
+;
+#endif
+
+/** Determine if `T` can be treated like a tuple during conversions.
+
+    Provides the member constant `value` that is equal to `true`, if
+    <tt>std::tuple_size<T>::value</tt> is a positive number. Otherwise, `value`
+    is equal to `false`.<br>
+
+    Users can specialize the trait for their own types if they don't want them
+    to be treated like tuples. For example:
+
+    @code
+    namespace boost {
+    namespace json {
+
+    template <>
+    struct is_tuple_like<your::tuple> : std::false_type
+    { };
+
+    } // namespace boost
+    } // namespace json
+    @endcode
+
+
+    @par Types satisfying the trait
+
+    <a href="https://en.cppreference.com/w/cpp/utility/tuple"><tt>std::tuple</tt></a>,
+    <a href="https://en.cppreference.com/w/cpp/utility/pair"><tt>std::pair</tt></a>.
+
+    @see @ref value_from, @ref value_to
+*/
+template<class T, class Enable = void>
+struct is_tuple_like
+#ifndef BOOST_JSON_DOCS
+    : mp11::mp_valid_and_true<detail::has_positive_tuple_size, T>
+{ };
+#else
+;
+#endif
+
+BOOST_JSON_NS_END
+
+#endif // BOOST_JSON_CONVERSION_HPP

--- a/include/boost/json/conversion.hpp
+++ b/include/boost/json/conversion.hpp
@@ -254,6 +254,41 @@ struct is_tuple_like
 ;
 #endif
 
+/** Determine if `T` can be treated like null during conversions.
+
+    Primary template instantiations provide the member constant `value` that is
+    equal to `false`. Users can specialize the trait for their own types if
+    they **do** want them to be treated as nulls. For example:
+
+    @code
+    namespace boost {
+    namespace json {
+
+    template <>
+    struct is_null_like<your::null_type> : std::true_type
+    { };
+
+    } // namespace boost
+    } // namespace json
+    @endcode
+
+
+    @par Types satisfying the trait
+
+    <a href="https://en.cppreference.com/w/cpp/types/nullptr_t"><tt>std::nullptr_t</tt></a>.
+
+    @see @ref value_from, @ref value_to
+*/
+template<class T, class Enable = void>
+struct is_null_like
+    : std::false_type
+{ };
+
+template<>
+struct is_null_like<std::nullptr_t>
+    : std::true_type
+{ };
+
 BOOST_JSON_NS_END
 
 #endif // BOOST_JSON_CONVERSION_HPP

--- a/include/boost/json/detail/value_from.hpp
+++ b/include/boost/json/detail/value_from.hpp
@@ -147,10 +147,6 @@ value_from_helper(
         "No suitable tag_invoke overload found for the type");
 }
 
-template<class T>
-using value_from_implementation
-    = conversion_implementation<T, value_from_conversion>;
-
 } // detail
 BOOST_JSON_NS_END
 

--- a/include/boost/json/detail/value_from.hpp
+++ b/include/boost/json/detail/value_from.hpp
@@ -83,8 +83,8 @@ value_from_helper(
     T&& from,
     string_like_conversion_tag)
 {
-    jv.emplace_string().assign(
-        from.data(), from.size());
+    auto sv = static_cast<string_view>(from);
+    jv.emplace_string().assign(sv);
 }
 
 // map-like types

--- a/include/boost/json/detail/value_from.hpp
+++ b/include/boost/json/detail/value_from.hpp
@@ -63,12 +63,13 @@ value_from_helper(
     jv = std::forward<T>(from);
 }
 
+// null-like types
 template<class T>
 void
 value_from_helper(
     value& jv,
     T&&,
-    nullptr_conversion_tag)
+    null_like_conversion_tag)
 {
     // do nothing
     BOOST_ASSERT(jv.is_null());

--- a/include/boost/json/detail/value_to.hpp
+++ b/include/boost/json/detail/value_to.hpp
@@ -202,7 +202,7 @@ value_to_impl(
     string_like_conversion_tag)
 {
     auto& str = jv.as_string();
-    return T(str.data(), str.size());
+    return T(str.subview());
 }
 
 // map-like containers

--- a/include/boost/json/detail/value_to.hpp
+++ b/include/boost/json/detail/value_to.hpp
@@ -284,10 +284,6 @@ value_to_impl(
     return tag_invoke(tag, jv);
 }
 
-template<class T>
-using value_to_implementation
-    = conversion_implementation<T, value_to_conversion>;
-
 // no suitable conversion implementation
 template<class T>
 T
@@ -300,6 +296,10 @@ value_to_impl(
         !std::is_same<T, T>::value,
         "No suitable tag_invoke overload found for the type");
 }
+
+template<class T>
+using value_to_implementation
+    = conversion_implementation<T, value_to_conversion>;
 
 } // detail
 BOOST_JSON_NS_END

--- a/include/boost/json/detail/value_to.hpp
+++ b/include/boost/json/detail/value_to.hpp
@@ -156,6 +156,21 @@ value_to_impl(
     return jv.as_string();
 }
 
+// nullptr conversion
+// this is barely useful, and provided mostly for consistency
+inline
+std::nullptr_t
+value_to_impl(
+    value_to_tag<std::nullptr_t>,
+    value const& jv,
+    nullptr_conversion_tag)
+{
+    if( jv.is_null() )
+        return nullptr;
+    detail::throw_invalid_argument(
+        "source value is not null", BOOST_JSON_SOURCE_POS);
+}
+
 // bool
 inline
 bool

--- a/include/boost/json/detail/value_to.hpp
+++ b/include/boost/json/detail/value_to.hpp
@@ -156,21 +156,6 @@ value_to_impl(
     return jv.as_string();
 }
 
-// nullptr conversion
-// this is barely useful, and provided mostly for consistency
-inline
-std::nullptr_t
-value_to_impl(
-    value_to_tag<std::nullptr_t>,
-    value const& jv,
-    nullptr_conversion_tag)
-{
-    if( jv.is_null() )
-        return nullptr;
-    detail::throw_invalid_argument(
-        "source value is not null", BOOST_JSON_SOURCE_POS);
-}
-
 // bool
 inline
 bool
@@ -191,6 +176,20 @@ value_to_impl(
     number_conversion_tag)
 {
     return jv.to_number<T>();
+}
+
+// null-like conversion
+template<class T>
+T
+value_to_impl(
+    value_to_tag<T>,
+    value const& jv,
+    null_like_conversion_tag)
+{
+    if( jv.is_null() )
+        return T();
+    detail::throw_invalid_argument(
+        "source value is not null", BOOST_JSON_SOURCE_POS);
 }
 
 // string-like types

--- a/include/boost/json/detail/value_traits.hpp
+++ b/include/boost/json/detail/value_traits.hpp
@@ -189,11 +189,11 @@ using conversion_implementation = mp11::mp_cond<
     // user conversion (via tag_invoke)
     has_user_conversion<T, Dir>,       user_conversion_tag,
     // native conversions (constructors and member functions of value)
-    std::is_same<T, std::nullptr_t>,   nullptr_conversion_tag,
     std::is_same<T, value>,            value_conversion_tag,
     std::is_same<T, array>,            array_conversion_tag,
     std::is_same<T, object>,           object_conversion_tag,
     std::is_same<T, string>,           string_conversion_tag,
+    std::is_same<T, std::nullptr_t>,   nullptr_conversion_tag,
     std::is_same<T, bool>,             bool_conversion_tag,
     std::is_arithmetic<T>,             number_conversion_tag,
     other_value_constructible<T, Dir>, native_conversion_tag,

--- a/include/boost/json/detail/value_traits.hpp
+++ b/include/boost/json/detail/value_traits.hpp
@@ -84,7 +84,7 @@ struct array_conversion_tag : native_conversion_tag { };
 struct string_conversion_tag : native_conversion_tag { };
 struct bool_conversion_tag : native_conversion_tag { };
 struct number_conversion_tag : native_conversion_tag { };
-struct nullptr_conversion_tag : native_conversion_tag { };
+struct null_like_conversion_tag { };
 struct string_like_conversion_tag { };
 struct map_like_conversion_tag { };
 struct sequence_conversion_tag { };
@@ -111,20 +111,20 @@ using has_user_conversion
 template<class T, class Dir>
 using conversion_implementation = mp11::mp_cond<
     // user conversion (via tag_invoke)
-    has_user_conversion<T, Dir>,     user_conversion_tag,
+    has_user_conversion<T, Dir>, user_conversion_tag,
     // native conversions (constructors and member functions of value)
-    std::is_same<T, value>,          value_conversion_tag,
-    std::is_same<T, array>,          array_conversion_tag,
-    std::is_same<T, object>,         object_conversion_tag,
-    std::is_same<T, string>,         string_conversion_tag,
-    std::is_same<T, std::nullptr_t>, nullptr_conversion_tag,
-    std::is_same<T, bool>,           bool_conversion_tag,
-    std::is_arithmetic<T>,           number_conversion_tag,
+    std::is_same<T, value>,      value_conversion_tag,
+    std::is_same<T, array>,      array_conversion_tag,
+    std::is_same<T, object>,     object_conversion_tag,
+    std::is_same<T, string>,     string_conversion_tag,
+    std::is_same<T, bool>,       bool_conversion_tag,
+    std::is_arithmetic<T>,       number_conversion_tag,
     // generic conversions
-    is_string_like<T>,               string_like_conversion_tag,
-    is_map_like<T>,                  map_like_conversion_tag,
-    is_sequence_like<T>,             sequence_conversion_tag,
-    is_tuple_like<T>,                tuple_conversion_tag,
+    is_null_like<T>,             null_like_conversion_tag,
+    is_string_like<T>,           string_like_conversion_tag,
+    is_map_like<T>,              map_like_conversion_tag,
+    is_sequence_like<T>,         sequence_conversion_tag,
+    is_tuple_like<T>,            tuple_conversion_tag,
     // failed to find a suitable implementation
     mp11::mp_true,                   no_conversion_tag>;
 

--- a/include/boost/json/detail/value_traits.hpp
+++ b/include/boost/json/detail/value_traits.hpp
@@ -176,13 +176,10 @@ using is_map_like = mp11::mp_all<
         key_type<T>,
         string_view>>;
 
+// matches char const*, but only for value_from
 template<class T, class Dir>
-using other_value_constructible = mp11::mp_and<
-    Dir, // is value_from_conversion
-    mp11::mp_or<
-        std::is_same<T, char const*>,
-        std::is_same<T, std::initializer_list<value_ref>>,
-        std::is_same<T, value_ref>>>;
+using is_char_star
+    = mp11::mp_and<Dir, std::is_same<T, char const*>>;
 
 template<class T, class Dir>
 using conversion_implementation = mp11::mp_cond<
@@ -196,7 +193,7 @@ using conversion_implementation = mp11::mp_cond<
     std::is_same<T, std::nullptr_t>,   nullptr_conversion_tag,
     std::is_same<T, bool>,             bool_conversion_tag,
     std::is_arithmetic<T>,             number_conversion_tag,
-    other_value_constructible<T, Dir>, native_conversion_tag,
+    is_char_star<T, Dir>,              native_conversion_tag,
     // generic conversions
     is_string_like<T>,                 string_like_conversion_tag,
     is_map_like<T, Dir>,               map_like_conversion_tag,

--- a/include/boost/json/detail/value_traits.hpp
+++ b/include/boost/json/detail/value_traits.hpp
@@ -208,6 +208,25 @@ using can_convert = mp11::mp_not<
         detail::conversion_implementation<T, Dir>,
         detail::no_conversion_tag>>;
 
+template<class T>
+using value_from_implementation
+    = conversion_implementation<T, value_from_conversion>;
+
+template<class T>
+using value_to_implementation
+    = conversion_implementation<T, value_to_conversion>;
+
+template<class Main, class Opposite>
+using conversion_round_trips_helper = mp11::mp_or<
+    std::is_same<Main, Opposite>,
+    std::is_same<user_conversion_tag, Main>,
+    std::is_same<user_conversion_tag, Opposite>,
+    std::is_same<no_conversion_tag, Opposite>>;
+template<class T, class Dir>
+using conversion_round_trips  = conversion_round_trips_helper<
+    conversion_implementation<T, Dir>,
+    conversion_implementation<T, mp11::mp_not<Dir>>>;
+
 } // detail
 BOOST_JSON_NS_END
 

--- a/include/boost/json/detail/value_traits.hpp
+++ b/include/boost/json/detail/value_traits.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2020 Krystian Stasiowski (sdkrystian@gmail.com)
+// Copyright (c) 2022 Dmitry Arkhipov (grisumbras@gmail.com)
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,18 +12,21 @@
 #define BOOST_JSON_DETAIL_VALUE_TRAITS_HPP
 
 #include <boost/json/detail/config.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/bind.hpp>
+#include <boost/mp11/function.hpp>
+#include <boost/mp11/utility.hpp>
 #include <type_traits>
 #include <utility>
 
 BOOST_JSON_NS_BEGIN
+
+struct value_from_tag { };
+
+template<class>
+struct value_to_tag { };
+
 namespace detail {
-
-template<std::size_t N>
-struct priority_tag
-    : priority_tag<N - 1> { };
-
-template<>
-struct priority_tag<0> { };
 
 using std::begin;
 using std::end;
@@ -30,124 +34,182 @@ using std::end;
 using std::size;
 #endif
 
-template<typename T, typename = void>
-struct container_traits
-{
-    static constexpr bool is_container = false;
-};
+template<std::size_t I, class T>
+using tuple_element_t = typename std::tuple_element<I, T>::type;
 
-template<typename T>
-struct container_traits<T, typename std::enable_if<
-    std::is_same<decltype(begin(std::declval<T&>())),
-        decltype(end(std::declval<T&>()))>::value>::type>
-{
-private:
-    template<typename U, typename std::enable_if<
-        std::is_convertible<decltype(std::declval<U&>().size()),
-            std::size_t>::value>::type* = nullptr>
-    static
-    std::size_t
-    size_impl(
-        U&& cont,
-        priority_tag<2>)
-    {
-        return cont.size();
-    }
-
-    template<typename U, typename std::enable_if<
-        std::is_convertible<decltype(size(std::declval<U&>())),
-            std::size_t>::value>::type* = nullptr>
-    static
-    std::size_t
-    size_impl(
-        U& cont,
-        priority_tag<1>)
-    {
-        return size(cont);
-    }
-
-    template<typename U, std::size_t N>
-    static
-    std::size_t
-    size_impl(
-        U(&)[N],
-        priority_tag<1>)
-    {
-        return N;
-    }
-
-    template<typename U>
-    static
-    std::size_t
-    size_impl(U&, priority_tag<0>)
-    {
-        return 0;
-    }
-
-public:
-    static constexpr bool is_container = true;
-    using value_type = remove_cvref<
-        decltype(*begin(std::declval<T&>()))>;
-
-    template<typename U>
-    static
-    std::size_t
-    try_size(U& cont)
-    {
-        return container_traits::size_impl(
-            cont, priority_tag<2>());
-    }
-};
-
-template<typename T, typename = void>
-struct map_traits
-{
-    static constexpr bool is_map = false;
-    static constexpr bool has_unique_keys = false;
-};
-
-template<typename T>
-struct map_traits<T, void_t<typename remove_cvref<T>::key_type,
-    typename std::enable_if<container_traits<T>::is_container &&
-        std::tuple_size<typename remove_cvref<T>::
-    value_type>::value == 2>::type>>
-{
-private:
-    template<typename U, typename = void>
-    struct unique_keys : std::false_type { };
-
-    template<typename U>
-    struct unique_keys<U, typename std::enable_if<
-        (std::tuple_size<remove_cvref<decltype(std::declval<
-            remove_cvref<U>&>().emplace(std::declval<typename
-        remove_cvref<U>::value_type>()))>>::value > 0)>::type>
-            : std::true_type { };
-public:
-    static constexpr bool is_map = true;
-    static constexpr bool has_unique_keys = unique_keys<T>::value;
-    using pair_key_type = typename std::tuple_element<
-        0, typename remove_cvref<T>::value_type>::type;
-    using pair_value_type = typename std::tuple_element<
-        1, typename remove_cvref<T>::value_type>::type;
-    static constexpr bool key_converts_to_string =
-        std::is_convertible<pair_key_type, string_view>::value;
-};
-
-// does not include std::nullptr_t
 template<class T>
-using value_constructible = std::integral_constant<bool,
-    std::is_same<detail::remove_cvref<T>, value>::value ||
-        std::is_same<detail::remove_cvref<T>, object>::value ||
-    std::is_same<detail::remove_cvref<T>, array>::value ||
-        std::is_same<detail::remove_cvref<T>, string>::value ||
-    std::is_same<detail::remove_cvref<T>, string_view>::value ||
-        std::is_arithmetic<detail::remove_cvref<T>>::value ||
-    std::is_same<detail::remove_cvref<T>, char const*>::value ||
-    std::is_same<detail::remove_cvref<T>,
-        std::initializer_list<value_ref>>::value ||
-    std::is_same<detail::remove_cvref<T>, value_ref>::value>;
+using value_type = remove_cvref< decltype(*begin(std::declval<T&>())) >;
+template<class T>
+using mapped_type = tuple_element_t< 1, value_type<T> >;
 
-BOOST_STATIC_ASSERT(value_constructible<value>::value);
+// had to make the metafunction always succeeding in order to make it work
+// with msvc 14.0
+template<class T>
+using key_type_helper = tuple_element_t< 0, value_type<T> >;
+template<class T>
+using key_type = mp11::mp_eval_or<
+    void,
+    key_type_helper,
+    T>;
+
+template<class T>
+using has_size_member_helper
+    = std::is_convertible<decltype(std::declval<T&>().size()), std::size_t>;
+template<class T>
+using has_size_member = mp11::mp_valid_and_true<has_size_member_helper, T>;;
+template<class T>
+using has_free_size_helper
+    = std::is_convertible<
+        decltype(size(std::declval<T const&>())),
+        std::size_t>;
+template<class T>
+using has_free_size = mp11::mp_valid_and_true<has_free_size_helper, T>;;
+template<class T>
+using size_implementation = mp11::mp_cond<
+    has_size_member<T>, mp11::mp_int<3>,
+    has_free_size<T>,   mp11::mp_int<2>,
+    std::is_array<T>,   mp11::mp_int<1>,
+    mp11::mp_true,      mp11::mp_int<0>>;
+
+template<class T>
+std::size_t
+try_size(T&& cont, mp11::mp_int<3>)
+{
+    return cont.size();
+}
+
+template<class T>
+std::size_t
+try_size(T& cont, mp11::mp_int<2>)
+{
+    return size(cont);
+}
+
+template<class T, std::size_t N>
+std::size_t
+try_size(T(&)[N], mp11::mp_int<1>)
+{
+    return N;
+}
+
+template<class T>
+std::size_t
+try_size(T&, mp11::mp_int<0>)
+{
+    return 0;
+}
+
+using value_from_conversion = mp11::mp_true;
+using value_to_conversion = mp11::mp_false;
+
+struct user_conversion_tag { };
+struct native_conversion_tag { };
+struct value_conversion_tag : native_conversion_tag { };
+struct object_conversion_tag : native_conversion_tag { };
+struct array_conversion_tag : native_conversion_tag { };
+struct string_conversion_tag : native_conversion_tag { };
+struct bool_conversion_tag : native_conversion_tag { };
+struct number_conversion_tag : native_conversion_tag { };
+struct nullptr_conversion_tag : native_conversion_tag { };
+struct string_like_conversion_tag { };
+struct map_like_conversion_tag { };
+struct sequence_conversion_tag { };
+struct tuple_conversion_tag { };
+struct no_conversion_tag { };
+
+template<class T>
+using has_user_conversion_from_impl
+    = decltype(tag_invoke(
+        value_from_tag(), std::declval<value&>(), std::declval<T&&>()));
+template<class T>
+using has_user_conversion_to_impl
+    = decltype(tag_invoke(
+        std::declval<value_to_tag<T>&>(), std::declval<value const &>()));
+template<class T, class Dir>
+using has_user_conversion
+    = mp11::mp_valid_q<
+        mp11::mp_if<
+            std::is_same<Dir, value_from_conversion>,
+            mp11::mp_quote<has_user_conversion_from_impl>,
+            mp11::mp_quote<has_user_conversion_to_impl>>,
+        T>;
+
+template<class T, class U>
+using is_data_convertible
+    = std::is_convertible<decltype(std::declval<T&>().data()), U>;
+template<class T>
+using is_string_like = mp11::mp_all<
+    std::is_constructible<T, char const*, std::size_t>,
+    mp11::mp_valid_and_true<is_data_convertible, T, char const*>,
+    mp11::mp_valid_and_true<has_size_member_helper, T>>;
+
+template<class T>
+using are_begin_and_end_same = std::is_same<
+    decltype(begin(std::declval<T&>())),
+    decltype(end(std::declval<T&>()))>;
+template <class T>
+using is_sequence_like = mp11::mp_valid_and_true<are_begin_and_end_same, T>;
+
+template<class T>
+using has_positive_tuple_size = mp11::mp_bool<
+    (std::tuple_size<T>::value > 0) >;
+template<class T>
+using is_tuple_like = mp11::mp_valid_and_true<has_positive_tuple_size, T>;
+
+template<class T>
+using has_unique_keys = has_positive_tuple_size<decltype(
+    std::declval<T&>().emplace(
+        std::declval<value_type<T>>()))>;
+template<class T>
+using is_value_type_pair
+    = mp11::mp_bool<std::tuple_size<value_type<T>>::value == 2>;
+template<class T, class Dir>
+using is_map_like = mp11::mp_all<
+    is_sequence_like<T>,
+    mp11::mp_valid_and_true<has_unique_keys, T>,
+    mp11::mp_valid_and_true<is_value_type_pair, T>,
+    mp11::mp_invoke_q<
+        mp11::mp_if<
+            Dir, // is value_from_conversion
+            mp11::mp_quote<std::is_convertible>,
+            mp11::mp_quote<std::is_constructible>>,
+        key_type<T>,
+        string_view>>;
+
+template<class T, class Dir>
+using other_value_constructible = mp11::mp_and<
+    Dir, // is value_from_conversion
+    mp11::mp_or<
+        std::is_same<T, char const*>,
+        std::is_same<T, std::initializer_list<value_ref>>,
+        std::is_same<T, value_ref>>>;
+
+template<class T, class Dir>
+using conversion_implementation = mp11::mp_cond<
+    // user conversion (via tag_invoke)
+    has_user_conversion<T, Dir>,       user_conversion_tag,
+    // native conversions (constructors and member functions of value)
+    std::is_same<T, std::nullptr_t>,   nullptr_conversion_tag,
+    std::is_same<T, value>,            value_conversion_tag,
+    std::is_same<T, array>,            array_conversion_tag,
+    std::is_same<T, object>,           object_conversion_tag,
+    std::is_same<T, string>,           string_conversion_tag,
+    std::is_same<T, bool>,             bool_conversion_tag,
+    std::is_arithmetic<T>,             number_conversion_tag,
+    other_value_constructible<T, Dir>, native_conversion_tag,
+    // generic conversions
+    is_string_like<T>,                 string_like_conversion_tag,
+    is_map_like<T, Dir>,               map_like_conversion_tag,
+    is_sequence_like<T>,               sequence_conversion_tag,
+    is_tuple_like<T>,                  tuple_conversion_tag,
+    // failed to find a suitable implementation
+    mp11::mp_true,                     no_conversion_tag>;
+
+template <class T, class Dir>
+using can_convert = mp11::mp_not<
+    std::is_same<
+        detail::conversion_implementation<T, Dir>,
+        detail::no_conversion_tag>>;
 
 } // detail
 BOOST_JSON_NS_END

--- a/include/boost/json/detail/value_traits.hpp
+++ b/include/boost/json/detail/value_traits.hpp
@@ -11,13 +11,7 @@
 #ifndef BOOST_JSON_DETAIL_VALUE_TRAITS_HPP
 #define BOOST_JSON_DETAIL_VALUE_TRAITS_HPP
 
-#include <boost/json/detail/config.hpp>
-#include <boost/mp11/algorithm.hpp>
-#include <boost/mp11/bind.hpp>
-#include <boost/mp11/function.hpp>
-#include <boost/mp11/utility.hpp>
-#include <type_traits>
-#include <utility>
+#include <boost/json/conversion.hpp>
 
 BOOST_JSON_NS_BEGIN
 
@@ -28,29 +22,9 @@ struct value_to_tag { };
 
 namespace detail {
 
-using std::begin;
-using std::end;
 #ifdef __cpp_lib_nonmember_container_access
 using std::size;
 #endif
-
-template<std::size_t I, class T>
-using tuple_element_t = typename std::tuple_element<I, T>::type;
-
-template<class T>
-using value_type = remove_cvref< decltype(*begin(std::declval<T&>())) >;
-template<class T>
-using mapped_type = tuple_element_t< 1, value_type<T> >;
-
-// had to make the metafunction always succeeding in order to make it work
-// with msvc 14.0
-template<class T>
-using key_type_helper = tuple_element_t< 0, value_type<T> >;
-template<class T>
-using key_type = mp11::mp_eval_or<
-    void,
-    key_type_helper,
-    T>;
 
 template<class T>
 using has_size_member_helper
@@ -133,36 +107,6 @@ using has_user_conversion
             mp11::mp_quote<has_user_conversion_from_impl>,
             mp11::mp_quote<has_user_conversion_to_impl>>,
         T>;
-
-template<class T>
-using is_string_like = std::is_convertible<T, string_view>;
-
-template<class T>
-using are_begin_and_end_same = std::is_same<
-    decltype(begin(std::declval<T&>())),
-    decltype(end(std::declval<T&>()))>;
-template <class T>
-using is_sequence_like = mp11::mp_valid_and_true<are_begin_and_end_same, T>;
-
-template<class T>
-using has_positive_tuple_size = mp11::mp_bool<
-    (std::tuple_size<T>::value > 0) >;
-template<class T>
-using is_tuple_like = mp11::mp_valid_and_true<has_positive_tuple_size, T>;
-
-template<class T>
-using has_unique_keys = has_positive_tuple_size<decltype(
-    std::declval<T&>().emplace(
-        std::declval<value_type<T>>()))>;
-template<class T>
-using is_value_type_pair
-    = mp11::mp_bool<std::tuple_size<value_type<T>>::value == 2>;
-template<class T>
-using is_map_like = mp11::mp_all<
-    is_sequence_like<T>,
-    is_string_like<key_type<T>>,
-    mp11::mp_valid_and_true<has_unique_keys, T>,
-    mp11::mp_valid_and_true<is_value_type_pair, T>>;
 
 template<class T, class Dir>
 using conversion_implementation = mp11::mp_cond<

--- a/include/boost/json/impl/value_ref.hpp
+++ b/include/boost/json/impl/value_ref.hpp
@@ -34,7 +34,7 @@ from_const(
     void const* p,
     storage_ptr sp)
 {
-    return value_from(
+    return value(
         *reinterpret_cast<
             T const*>(p),
         std::move(sp));
@@ -47,7 +47,7 @@ from_rvalue(
     void* p,
     storage_ptr sp)
 {
-    return value_from(
+    return value(
         std::move(
             *reinterpret_cast<T*>(p)),
         std::move(sp));

--- a/include/boost/json/value_from.hpp
+++ b/include/boost/json/value_from.hpp
@@ -77,6 +77,8 @@ value_from(
     value& jv)
 {
     using bare_T = detail::remove_cvref<T>;
+    BOOST_STATIC_ASSERT(detail::conversion_round_trips<
+        bare_T, detail::value_from_conversion>::value);
     using impl = detail::value_from_implementation<bare_T>;
     detail::value_from_helper(jv, std::forward<T>(t), impl());
 }

--- a/include/boost/json/value_to.hpp
+++ b/include/boost/json/value_to.hpp
@@ -79,9 +79,11 @@ T
 value_to(const value& jv)
 {
     BOOST_STATIC_ASSERT(! std::is_reference<T>::value);
-    using impl = detail::value_to_implementation<detail::remove_cvref<T>>;
-    return detail::value_to_impl(
-        value_to_tag<detail::remove_cvref<T>>(), jv, impl());
+    using bare_T = detail::remove_cvref<T>;
+    BOOST_STATIC_ASSERT(detail::conversion_round_trips<
+        bare_T, detail::value_to_conversion>::value);
+    using impl = detail::value_to_implementation<bare_T>;
+    return detail::value_to_impl(value_to_tag<bare_T>(), jv, impl());
 }
 
 /** Convert a @ref value to an object of type `T`.

--- a/include/boost/json/value_to.hpp
+++ b/include/boost/json/value_to.hpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2019 Vinnie Falco (vinnie.falco@gmail.com)
 // Copyright (c) 2020 Krystian Stasiowski (sdkrystian@gmail.com)
+// Copyright (c) 2022 Dmitry Arkhipov (grisumbras@gmail.com)
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -78,8 +79,9 @@ T
 value_to(const value& jv)
 {
     BOOST_STATIC_ASSERT(! std::is_reference<T>::value);
+    using impl = detail::value_to_implementation<detail::remove_cvref<T>>;
     return detail::value_to_impl(
-        value_to_tag<typename std::remove_cv<T>::type>(), jv);
+        value_to_tag<detail::remove_cvref<T>>(), jv, impl());
 }
 
 /** Convert a @ref value to an object of type `T`.
@@ -113,18 +115,9 @@ value_to(U const& jv) = delete;
 template<class T>
 using has_value_to = __see_below__;
 #else
-template<class T, class>
-struct has_value_to
-    : std::false_type { };
-
 template<class T>
-struct has_value_to<T, detail::void_t<decltype(
-    detail::value_to_impl(
-        value_to_tag<detail::remove_cvref<T>>(),
-        std::declval<const value&>())),
-    typename std::enable_if<
-        ! std::is_reference<T>::value>::type
-    > > : std::true_type { };
+using has_value_to = detail::can_convert<
+    detail::remove_cvref<T>, detail::value_to_conversion>;
 #endif
 
 BOOST_JSON_NS_END

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -12,6 +12,7 @@ import testing ;
 local SOURCES =
     array.cpp
     basic_parser.cpp
+    conversion.cpp
     doc_background.cpp
     doc_forward_conversion.cpp
     doc_parsing.cpp

--- a/test/conversion.cpp
+++ b/test/conversion.cpp
@@ -70,9 +70,17 @@ struct my_null { };
 namespace std
 {
 
+// some versions of libstdc++ forward-declare tuple_size as class
+#if defined(__clang__) || ( defined(__GNUC__) && __GNUC__ >= 10 )
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmismatched-tags"
+#endif
 template<>
 struct tuple_size<pseudo_tuple1> : std::integral_constant<std::size_t, 2>
 { };
+#if defined(__clang__) || ( defined(__GNUC__) && __GNUC__ >= 10 )
+# pragma GCC diagnostic pop
+#endif
 
 } // namespace std
 

--- a/test/conversion.cpp
+++ b/test/conversion.cpp
@@ -1,0 +1,126 @@
+//
+// Copyright (c) 2022 Dmitry Arkhipov (grisumbras@yandex.ru)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/json
+//
+
+// test that header file is self-contained
+#include <boost/json/conversion.hpp>
+// test that header file is header-guarded properly
+#include <boost/json/conversion.hpp>
+
+#include "test.hpp"
+#include "test_suite.hpp"
+
+namespace
+{
+
+struct pseudo_string1
+{
+    operator boost::json::string_view();
+};
+
+struct pseudo_string2 : pseudo_string1
+{ };
+
+struct pseudo_sequence1
+{
+    int* begin();
+    int* end();
+};
+
+struct pseudo_sequence2 : pseudo_sequence1
+{ };
+
+struct pseudo_tuple1
+{ };
+
+struct pseudo_tuple2
+{ };
+
+template<class Key>
+struct pseudo_map1
+{
+    std::pair<Key, int>* begin();
+    std::pair<Key, int>* end();
+
+    std::pair< std::pair<Key, int>*, bool >
+    emplace(std::pair<Key, int>);
+
+};
+
+template<class Key>
+struct pseudo_multimap1
+{
+    std::pair<Key, int>* begin();
+    std::pair<Key, int>* end();
+
+    std::pair<Key, int>*
+    emplace(std::pair<Key, int>);
+
+};
+
+struct my_null { };
+
+} // namespace
+
+namespace std
+{
+
+template<>
+struct tuple_size<pseudo_tuple1> : std::integral_constant<std::size_t, 2>
+{ };
+
+} // namespace std
+
+BOOST_JSON_NS_BEGIN
+
+template <>
+struct is_string_like<pseudo_string2> : std::false_type
+{ };
+
+template <>
+struct is_sequence_like<pseudo_sequence2> : std::false_type
+{ };
+
+template <>
+struct is_tuple_like<pseudo_tuple2> : std::false_type
+{ };
+
+template <>
+struct is_null_like<my_null> : std::true_type
+{ };
+
+class conversion_test
+{
+public:
+    void
+    run()
+    {
+        BOOST_STATIC_ASSERT( is_string_like<pseudo_string1>::value );
+        BOOST_STATIC_ASSERT( !is_string_like<pseudo_string2>::value );
+
+        BOOST_STATIC_ASSERT( is_sequence_like<pseudo_sequence1>::value );
+        BOOST_STATIC_ASSERT( !is_sequence_like<pseudo_sequence2>::value );
+
+        BOOST_STATIC_ASSERT( is_tuple_like<pseudo_tuple1>::value );
+        BOOST_STATIC_ASSERT( !is_tuple_like<pseudo_tuple2>::value );
+
+        BOOST_STATIC_ASSERT(
+            is_map_like< pseudo_map1<pseudo_string1> >::value );
+        BOOST_STATIC_ASSERT(
+            !is_map_like< pseudo_map1<pseudo_string2> >::value );
+        BOOST_STATIC_ASSERT(
+            !is_map_like< pseudo_multimap1<pseudo_string1> >::value );
+
+        BOOST_STATIC_ASSERT( is_null_like<std::nullptr_t>::value );
+        BOOST_STATIC_ASSERT( is_null_like<my_null>::value );
+    }
+};
+
+TEST_SUITE(conversion_test, "boost.json.conversion");
+
+BOOST_JSON_NS_END

--- a/test/value.cpp
+++ b/test/value.cpp
@@ -844,6 +844,13 @@ public:
                 BOOST_TEST(jv.is_array());
                 BOOST_TEST(*jv.storage() == *sp);
             }
+            {
+                value jv(sp);
+                array const arr;
+                jv = arr;
+                BOOST_TEST(jv.is_array());
+                BOOST_TEST(*jv.storage() == *sp);
+            }
         }
 
         // operator=(object)
@@ -857,6 +864,13 @@ public:
             {
                 value jv(sp);
                 jv = object();
+                BOOST_TEST(jv.is_object());
+                BOOST_TEST(*jv.storage() == *sp);
+            }
+            {
+                value jv(sp);
+                object const obj;
+                jv = obj;
                 BOOST_TEST(jv.is_object());
                 BOOST_TEST(*jv.storage() == *sp);
             }

--- a/test/value_from.cpp
+++ b/test/value_from.cpp
@@ -25,7 +25,8 @@
 
 //----------------------------------------------------------
 
-namespace value_from_test_ns {
+namespace value_from_test_ns
+{
 
 //----------------------------------------------------------
 
@@ -114,7 +115,9 @@ size(T6 const&)
     return 3;
 }
 
-} // value_from_test_ns
+struct T7 { };
+
+} // namespace value_from_test_ns
 
 template<class T>
 static
@@ -140,6 +143,11 @@ check(
 }
 
 BOOST_JSON_NS_BEGIN
+
+template<>
+struct is_null_like<::value_from_test_ns::T7>
+    : std::true_type
+{ };
 
 namespace {
 
@@ -248,6 +256,11 @@ public:
             value c = value_from(a);
             BOOST_TEST(c.is_array());
             BOOST_TEST(serialize(c) == serialize(b));
+        }
+        {
+            ::value_from_test_ns::T7 a;
+            value b = value_from(a);
+            BOOST_TEST(b.is_null());
         }
     }
 

--- a/test/value_from.cpp
+++ b/test/value_from.cpp
@@ -103,6 +103,17 @@ tag_invoke(
 
 //----------------------------------------------------------
 
+struct T6
+{
+};
+
+inline
+std::size_t
+size(T6 const&)
+{
+    return 3;
+}
+
 } // value_from_test_ns
 
 template<class T>
@@ -291,6 +302,31 @@ public:
     }
 
     void
+    testTrySize()
+    {
+        {
+            std::vector<int> v{1, 2, 3};
+            using impl = detail::size_implementation<decltype(v)>;
+            BOOST_TEST(detail::try_size(v, impl()) == 3);
+        }
+        {
+            int arr[4] = {1, 2, 3, 4};
+            using impl = detail::size_implementation<decltype(arr)>;
+            BOOST_TEST(detail::try_size(arr, impl()) == 4);
+        }
+        {
+            value_from_test_ns::T6 t;
+            using impl = detail::size_implementation<decltype(t)>;
+            BOOST_TEST(detail::try_size(t, impl()) == 3);
+        }
+        {
+            value_from_test_ns::T1 t;
+            using impl = detail::size_implementation<decltype(t)>;
+            BOOST_TEST(detail::try_size(t, impl()) == 0);
+        }
+    }
+
+    void
     run()
     {
         check("42", ::value_from_test_ns::T1{});
@@ -300,6 +336,7 @@ public:
         testGeneral();
         testAssociative();
         testPreferUserCustomizations();
+        testTrySize();
     }
 };
 

--- a/test/value_from.cpp
+++ b/test/value_from.cpp
@@ -65,7 +65,7 @@ tag_invoke(
     ::boost::json::value& jv,
     T2 const& t)
 {
-    jv = { t.v, t.s };
+    jv = { boost::json::value_from(t.v), boost::json::value_from(t.s) };
 }
 
 struct T3

--- a/test/value_to.cpp
+++ b/test/value_to.cpp
@@ -80,6 +80,10 @@ public:
         {
             {"a", 1}, {"b", 2}, {"c", 3}
         });
+        check(std::multimap<std::string, int>
+        {
+            {"2", 4}, {"3", 9}, {"5", 25}
+        });
         check(std::unordered_map<std::string, int>
         {
             { "a", 1 }, {"b", 2}, {"c", 3}
@@ -115,11 +119,37 @@ public:
     }
 
     void
+    testContainerHelpers()
+    {
+        {
+            std::vector<int> v;
+            detail::try_reserve(
+                v, 10, detail::reserve_implementation<decltype(v)>());
+            BOOST_TEST(v.capacity() >= 10);
+            BOOST_STATIC_ASSERT(std::is_same<
+                decltype(detail::inserter(
+                    v, detail::inserter_implementation<decltype(v)>())),
+                decltype(std::back_inserter(v)) >::value);
+        }
+        {
+            std::array<int, 2> arr;
+            detail::try_reserve(
+                arr, 2, detail::reserve_implementation<decltype(arr)>());
+        }
+        {
+            int n;
+            detail::try_reserve(
+                n, 5, detail::reserve_implementation<decltype(n)>());
+        }
+    }
+
+    void
     run()
     {
         testNumberCast();
         testJsonTypes();
         testGenerics();
+        testContainerHelpers();
     }
 };
 

--- a/test/value_to.cpp
+++ b/test/value_to.cpp
@@ -17,8 +17,17 @@
 #include <unordered_map>
 #include <vector>
 
+namespace value_to_test_ns
+{
+
+struct T1 { };
+
+} // namespace value_to_test_ns
+
 BOOST_JSON_NS_BEGIN
 
+template<>
+struct is_null_like<::value_to_test_ns::T1> : std::true_type { };
 
 template <class T, class = void>
 struct can_apply_value_to
@@ -35,7 +44,6 @@ struct can_apply_value_to<T, detail::void_t<decltype(
 };
 
 BOOST_STATIC_ASSERT(!can_apply_value_to<int>::value);
-
 
 class value_to_test
 {
@@ -146,8 +154,12 @@ public:
     void testNullptr()
     {
         (void)value_to<std::nullptr_t>(value());
+        (void)value_to<::value_to_test_ns::T1>(value());
         BOOST_TEST_THROWS(
             (value_to<std::nullptr_t>(value(1))), std::invalid_argument);
+        BOOST_TEST_THROWS(
+            (value_to<::value_to_test_ns::T1>(value(1))),
+            std::invalid_argument);
     }
 
     void

--- a/test/value_to.cpp
+++ b/test/value_to.cpp
@@ -143,6 +143,13 @@ public:
         }
     }
 
+    void testNullptr()
+    {
+        (void)value_to<std::nullptr_t>(value());
+        BOOST_TEST_THROWS(
+            (value_to<std::nullptr_t>(value(1))), std::invalid_argument);
+    }
+
     void
     run()
     {
@@ -150,6 +157,7 @@ public:
         testJsonTypes();
         testGenerics();
         testContainerHelpers();
+        testNullptr();
     }
 };
 


### PR DESCRIPTION
The list of changes:
* take advantage of mp11
* split `container_traits` into several traits and helpers
* split `map_traits` into several traits
* use `value_type` more consistently
* refactor `detail::inserter`
* use `detail::inserter` with map-like types
* refactor conversion of tuple-like to array
* remove conversion from `value_ref` and don't use `value_to/from` when constructing `value` from `value_ref`
* check for round-trip
* user-facing conversion traits
* opt-in null-like conversion
* same requirements for `value_to` and `value_from`
* stricter `is_map_like`
* stricter `is_sequence_like`