### PR TITLE
Update GHA, remove windows-2016

### DIFF
--- a/.github/actions/setup-packages/action.yml
+++ b/.github/actions/setup-packages/action.yml
@@ -41,8 +41,8 @@ runs:
             . /etc/lsb-release
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
             LLVM_DISTRIB=llvm-toolchain-${DISTRIB_CODENAME}
-            if test -n "${{ inputs.llvm_version }}" ; then
-                LLVM_DISTRIB=${LLVM_DISTRIB}-${{ inputs.llvm_version }}
+            if test -n "${{ inputs.version }}" ; then
+                LLVM_DISTRIB=${LLVM_DISTRIB}-${{ inputs.version }}
             fi
             sudo -E apt-add-repository "deb http://apt.llvm.org/${DISTRIB_CODENAME}/ ${LLVM_DISTRIB} main"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,18 +198,18 @@ jobs:
             container: "ubuntu:16.04"
             toolset: "clang"
             comment: "Coverity Scan"
-          - name: "msvc-14.1"
-            buildtype: "boost"
-            os: "windows-2016"
-            toolset: "msvc"
-            toolset_version: "14.1"
-            b2_cxxstd: "11,14,17"
           - name: "msvc-14.2"
             buildtype: "boost"
             os: "windows-2019"
             toolset: "msvc"
             toolset_version: "14.2"
-            b2_cxxstd: "17,latest"
+            b2_cxxstd: "17,20"
+          - name: "msvc-14.3"
+            buildtype: "boost"
+            os: "windows-2022"
+            toolset: "msvc"
+            toolset_version: "14.3"
+            b2_cxxstd: "17,20"
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
@@ -225,7 +225,7 @@ jobs:
         with:
           install: ${{ matrix.packages }}
           toolset: ${{ matrix.toolset }}
-          llvm_version: ${{ matrix.toolset_version }}
+          version: ${{ matrix.toolset_version }}
 
       - uses: ./.github/actions/build
         with:


### PR DESCRIPTION
- Remove windows-2016  
- Add windows-2022
- Github Actions has been displaying warnings:

```
Unexpected input(s) 'llvm_version', valid inputs are ['install', 'remove', 'sources', 'toolset', 'version']
```

because the file .github/actions/setup-packages/action.yml doesn't list llvm_version as an input. It can be corrected with this section.  

```
  llvm_version:
    description: LLVM version to install
    required: false
    default: ''
```

However, the file action.yml file already has a 'version' input parameter. Why not leverage the existing 'version' variable instead of adding another one. That's what is done in this PR, @grisumbras  if there's a reason to keep 'llvm_version' distinct from 'version' let me know and I'll change it back.
