### PR TITLE
More explicitly document invalidation rules

### DIFF
--- a/doc/qbk/03_04_object.qbk
+++ b/doc/qbk/03_04_object.qbk
@@ -54,6 +54,17 @@ which creates a null element if the key does not already exist:
 Internally, the container computes a hash table over the keys
 so that the complexity of lookups is in constant time, on average.
 
+[warning
+    Unlike traditional node based containers like `std::set`, there is no
+    reference stability or iterator stability.
+]
+
+For example:
+
+[snippet_objects_5]
+
+Using `arr` after adding another value to `obj` results in undefined behavior.
+
 For the complete listing of all available member functions and nested
 types, see the reference page for __object__.
 

--- a/test/snippets.cpp
+++ b/test/snippets.cpp
@@ -495,6 +495,15 @@ usingObjects()
     catch (...)
     {
     }
+    {
+        //[snippet_objects_5
+
+        object obj{{"arr", {1, 11}}};
+        value& arr = obj.at("arr");
+        obj.emplace("added", "value"); // invalidates arr
+
+        //]
+    }
 }
 
 //----------------------------------------------------------


### PR DESCRIPTION
The reference/iterator invalidation rules can surprise people who expect
associative containers to be node-based, similar to `std::[unordered_]map`.

This calls it out more visibly to avoid surprises.