### PR TITLE
set_at_pointer

### DIFF
--- a/doc/qbk/dom/nested_access.qbk
+++ b/doc/qbk/dom/nested_access.qbk
@@ -1,10 +1,10 @@
 [/
-    Copyright (c) 2022 Dmitry Arkhipov (grisumbras@gmail.com)
+    Copyright (c) 2022 Dmitry Arkhipov (grisumbras@yandex.ru)
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-    Official repository: https://github.com/cppalliance/json
+    Official repository: https://github.com/boostorg/json
 ]
 
 [/-----------------------------------------------------------------------------]
@@ -25,5 +25,19 @@ For example, compare
 with
 
 [snippet_pointer_3]
+
+The library also allows changing and adding deeply nested elements. The
+function [link json.ref.boost__json__value.set_at_pointer `set_at_pointer`]
+traverses the value similarly to [link json.ref.boost__json__value.at_pointer
+`at_pointer`], but additionally, it can create missing elements in certain
+cases:
+
+[snippet_pointer_4]
+
+The specific behavior is controlled by an optional parameter of type [link
+json.ref.boost__json__set_pointer_options `set_pointer_options`]. For example,
+here's the same example with a different option:
+
+[snippet_pointer_5]
 
 [endsect]

--- a/doc/qbk/quickref.xml
+++ b/doc/qbk/quickref.xml
@@ -28,6 +28,7 @@
           <member><link linkend="json.ref.boost__json__parser">parser</link></member>
           <member><link linkend="json.ref.boost__json__parse_options">parse_options</link></member>
           <member><link linkend="json.ref.boost__json__serializer">serializer</link></member>
+          <member><link linkend="json.ref.boost__json__set_pointer_options">set_pointer_options</link></member>
           <member><link linkend="json.ref.boost__json__static_resource">static_resource</link></member>
           <member><link linkend="json.ref.boost__json__storage_ptr">storage_ptr</link></member>
           <member><link linkend="json.ref.boost__json__stream_parser">stream_parser</link></member>

--- a/include/boost/json.hpp
+++ b/include/boost/json.hpp
@@ -28,6 +28,7 @@
 #include <boost/json/pilfer.hpp>
 #include <boost/json/serialize.hpp>
 #include <boost/json/serializer.hpp>
+#include <boost/json/set_pointer_options.hpp>
 #include <boost/json/static_resource.hpp>
 #include <boost/json/storage_ptr.hpp>
 #include <boost/json/stream_parser.hpp>

--- a/include/boost/json/impl/pointer.ipp
+++ b/include/boost/json/impl/pointer.ipp
@@ -22,11 +22,12 @@ public:
     class iterator;
 
     pointer_token(
-        char const* b,
-        char const* e) noexcept
-        : b_(b)
-        , e_(e)
+        string_view sv) noexcept
+        : b_( sv.begin() + 1 )
+        , e_( sv.end() )
     {
+        BOOST_ASSERT( !sv.empty() );
+        BOOST_ASSERT( *sv.data() == '/' );
     }
 
     iterator begin() const noexcept;
@@ -142,7 +143,9 @@ bool is_invalid_zero(
     ++b;
     if( b == e )
         return false;
-    return *b != '/';
+
+    BOOST_ASSERT( *b != '/' );
+    return true;
 }
 
 bool is_past_the_end_token(
@@ -153,17 +156,22 @@ bool is_past_the_end_token(
         return false;
 
     ++b;
-    if( b == e )
-        return true;
-    return *b == '/';
+    BOOST_ASSERT( (b == e) || (*b != '/') );
+    return b == e;
 }
 
 std::size_t
 parse_number_token(
-    char const*& b,
-    char const* e,
+    string_view sv,
     error_code& ec) noexcept
 {
+    BOOST_ASSERT( !sv.empty() );
+
+    char const* b = sv.begin();
+    BOOST_ASSERT( *b == '/' );
+
+    ++b;
+    char const* const e = sv.end();
     if( ( b == e )
         || is_invalid_zero(b, e) )
     {
@@ -173,6 +181,7 @@ parse_number_token(
 
     if( is_past_the_end_token(b, e) )
     {
+        ++b;
         BOOST_JSON_FAIL(ec, error::past_the_end);
         return {};
     }
@@ -181,9 +190,7 @@ parse_number_token(
     for( ; b != e; ++b )
     {
         char const c = *b;
-
-        if( '/' == c)
-            break;
+        BOOST_ASSERT( c != '/' );
 
         unsigned d = c - '0';
         if( d > 9 )
@@ -205,13 +212,23 @@ parse_number_token(
     return result;
 }
 
-pointer_token
-get_token(
-    char const* b,
-    char const* e,
+string_view
+next_segment(
+    string_view& sv,
     error_code& ec) noexcept
 {
-    char const* start = b;
+    if( sv.empty() )
+        return sv;
+
+    char const* const start = sv.begin();
+    char const* b = start;
+    if( *b++ != '/' )
+    {
+        BOOST_JSON_FAIL( ec, error::missing_slash );
+        return {};
+    }
+
+    char const* e = sv.end();
     for( ; b < e; ++b )
     {
         char const c = *b;
@@ -222,7 +239,7 @@ get_token(
         {
             if( ++b == e )
             {
-                BOOST_JSON_FAIL(ec, error::invalid_escape);
+                BOOST_JSON_FAIL( ec, error::invalid_escape );
                 break;
             }
 
@@ -233,7 +250,7 @@ get_token(
                 // valid escape sequence
                 continue;
             default: {
-                BOOST_JSON_FAIL(ec, error::invalid_escape);
+                BOOST_JSON_FAIL( ec, error::invalid_escape );
                 break;
             }
             }
@@ -241,7 +258,8 @@ get_token(
         }
     }
 
-    return pointer_token(start, b);
+    sv.remove_prefix( b - start );
+    return string_view( start, b );
 }
 
 value*
@@ -257,6 +275,69 @@ if_contains_token(object const& obj, pointer_token token)
     return &it->value();
 }
 
+template<
+    class Value,
+    class OnObject,
+    class OnArray,
+    class OnScalar >
+Value*
+walk_pointer(
+    Value& jv,
+    string_view sv,
+    error_code& ec,
+    OnObject on_object,
+    OnArray on_array,
+    OnScalar on_scalar)
+{
+    ec.clear();
+
+    string_view segment = detail::next_segment( sv, ec );
+
+    Value* result = &jv;
+    while( true )
+    {
+        if( ec.failed() )
+            return nullptr;
+
+        if( !result )
+        {
+            BOOST_JSON_FAIL(ec, error::not_found);
+            return nullptr;
+        }
+
+        if( segment.empty() )
+            break;
+
+        switch( result->kind() )
+        {
+        case kind::object: {
+            auto& obj = result->get_object();
+
+            detail::pointer_token const token( segment );
+            segment = detail::next_segment( sv, ec );
+
+            result = on_object( obj, token );
+            break;
+        }
+        case kind::array: {
+            auto const index = detail::parse_number_token( segment, ec );
+            segment = detail::next_segment( sv, ec );
+
+            auto& arr = result->get_array();
+            result = on_array( arr, index, ec );
+            break;
+        }
+        default: {
+            if( on_scalar( *result, segment ) )
+                break;
+            BOOST_JSON_FAIL( ec, error::value_is_scalar );
+        }}
+    }
+
+    BOOST_ASSERT( result );
+    return result;
+}
+
 } // namespace detail
 
 value const&
@@ -270,53 +351,28 @@ value::at_pointer(string_view ptr) const&
 }
 
 value const*
-value::find_pointer(string_view ptr, error_code& ec) const noexcept
+value::find_pointer( string_view sv, error_code& ec ) const noexcept
 {
-    ec.clear();
-
-    value const* result = this;
-    char const* cur = ptr.data();
-    char const* const end = cur + ptr.size();
-    while( end != cur )
-    {
-        if( *cur++ != '/' )
+    return detail::walk_pointer(
+        *this,
+        sv,
+        ec,
+        []( object const& obj, detail::pointer_token token )
         {
-            BOOST_JSON_FAIL(ec, error::missing_slash);
-            return nullptr;
-        }
-
-        if( auto const po = result->if_object() )
+            return detail::if_contains_token(obj, token);
+        },
+        []( array const& arr, std::size_t index, error_code& ec )
+            -> value const*
         {
-            auto const token = detail::get_token(cur, end, ec);
             if( ec )
                 return nullptr;
 
-            result = detail::if_contains_token(*po, token);
-            cur = token.end().base();
-        }
-        else if( auto const pa = result->if_array() )
+            return arr.if_contains(index);
+        },
+        []( value const&, string_view)
         {
-            auto const index = detail::parse_number_token(cur, end, ec);
-            if( ec )
-                return nullptr;
-
-            result = pa->if_contains(index);
-        }
-        else
-        {
-            BOOST_JSON_FAIL(ec, error::value_is_scalar);
-            return nullptr;
-        }
-
-        if( !result )
-        {
-            BOOST_JSON_FAIL(ec, error::not_found);
-            return nullptr;
-        }
-    }
-
-    BOOST_ASSERT(result);
-    return result;
+            return std::false_type();
+        });
 }
 
 value*
@@ -340,6 +396,102 @@ value::find_pointer(string_view ptr, std::error_code& ec) noexcept
 {
     value const& self = *this;
     return const_cast<value*>(self.find_pointer(ptr, ec));
+}
+
+value*
+value::set_at_pointer(
+    string_view sv,
+    value_ref ref,
+    error_code& ec,
+    set_pointer_options const& opts )
+{
+    value* result = detail::walk_pointer(
+        *this,
+        sv,
+        ec,
+        []( object& obj, detail::pointer_token token)
+        {
+            if( !obj.empty() )
+            {
+                key_value_pair* kv = detail::find_in_object( obj, token ).first;
+                if( kv )
+                    return &kv->value();
+            }
+
+            string key( token.begin(), token.end(), obj.storage() );
+            return &obj.emplace( std::move(key), nullptr ).first->value();
+        },
+        [ &opts ]( array& arr, std::size_t index, error_code& ec ) -> value*
+        {
+            if( ec == error::past_the_end )
+                index = arr.size();
+            else if( ec.failed() )
+                return nullptr;
+
+            if( index >= arr.size() )
+            {
+                std::size_t const n = index - arr.size();
+                if( n >= opts.max_created_elements )
+                    return nullptr;
+
+                arr.resize( arr.size() + n + 1 );
+            }
+
+            ec.clear();
+            return arr.data() + index;
+        },
+        [ &opts ]( value& jv, string_view segment )
+        {
+            if( jv.is_null() || opts.replace_any_scalar )
+            {
+                if( opts.create_arrays )
+                {
+                    error_code ec;
+                    detail::parse_number_token( segment, ec );
+                    if( !ec.failed() || ec == error::past_the_end )
+                    {
+                        jv = array( jv.storage() );
+                        return true;
+                    }
+                }
+
+                if( opts.create_objects )
+                {
+                    jv = object( jv.storage() );
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+    if( result )
+        *result = ref.make_value( storage() );
+    return result;
+}
+
+value*
+value::set_at_pointer(
+    string_view sv,
+    value_ref ref,
+    std::error_code& ec,
+    set_pointer_options const& opts )
+{
+    error_code jec;
+    value* result = set_at_pointer( sv, ref, jec, opts );
+    ec = jec;
+    return result;
+}
+
+value&
+value::set_at_pointer(
+    string_view sv, value_ref ref, set_pointer_options const& opts )
+{
+    error_code ec;
+    value* result = set_at_pointer( sv, ref, ec, opts );
+    if( !result )
+        detail::throw_system_error(ec, BOOST_CURRENT_LOCATION);
+    return *result;
 }
 
 BOOST_JSON_NS_END

--- a/include/boost/json/set_pointer_options.hpp
+++ b/include/boost/json/set_pointer_options.hpp
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2022 Dmitry Arkhipov (grisumbras@yandex.ru)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/json
+//
+
+#ifndef BOOST_JSON_SET_POINTER_OPTIONS_HPP
+#define BOOST_JSON_SET_POINTER_OPTIONS_HPP
+
+#include <boost/json/detail/config.hpp>
+
+BOOST_JSON_NS_BEGIN
+
+/** Options for @ref value::set_at_pointer
+ *
+ * This structure is used for controlling behavior of
+ * @ref value::set_at_pointer regarding creation of intermediate elements.
+ */
+struct set_pointer_options
+{
+    /** Whether to create arrays
+
+        The option controls whether arrays are created when a pointer token is
+        a number or a past-the-end marker.
+    */
+    bool create_arrays = true;
+
+    /** Whether to create objects
+
+        The option controls whether objects are created for valid pointer
+        tokens.
+    */
+    bool create_objects = true;
+
+    /** Whether to replace non-null scalars
+
+        If the option is `true` any non-object, non-array value can be replaced
+        by either an @ref object or a @ref array. If it's `false`, only `null`
+        values can be replaced.
+    */
+    bool replace_any_scalar = false;
+
+
+    /** Maximum amount of elements added per one pointer token
+
+        When addressing @ref array elements the number represented by pointer
+        token can exceed the size of the array. In that case several elements
+        may be created to satisfy the request. This option limits the amount of
+        elements that can be added per one pointer token. This can be
+        important, because in general such operations can be dangerous, since a
+        relatively small string `"/18446744073709551616"` can request all of
+        the machine's memory. For that reason the default value for this option
+        is 1, that is no more than 1 element can be added per one pointer
+        token.
+    */
+    std::size_t max_created_elements = 1;
+};
+
+
+BOOST_JSON_NS_END
+
+#endif // BOOST_JSON_SET_POINTER_OPTIONS_HPP

--- a/include/boost/json/value.hpp
+++ b/include/boost/json/value.hpp
@@ -16,6 +16,7 @@
 #include <boost/json/kind.hpp>
 #include <boost/json/object.hpp>
 #include <boost/json/pilfer.hpp>
+#include <boost/json/set_pointer_options.hpp>
 #include <boost/json/storage_ptr.hpp>
 #include <boost/json/string.hpp>
 #include <boost/json/string_view.hpp>
@@ -3265,6 +3266,152 @@ public:
     value*
     find_pointer(string_view ptr, std::error_code& ec) noexcept;
 /** @} */
+
+    //------------------------------------------------------
+
+    /** Set an element via JSON Pointer.
+
+        This function is used to insert or assign to a potentially nested
+        element of the value using a JSON Pointer string. The function may
+        create intermediate elements corresponding to pointer segments.
+        <br/>
+
+        The particular conditions when and what kind of intermediate element
+        is created is governed by the `ptr` parameter.
+
+        Each pointer token is considered in sequence. For each token
+
+        - if the containing value is an @ref object, then a new `null`
+        element is created with key equal to unescaped token string; otherwise
+
+        - if the containing value is an @ref array, and the token represents a
+        past-the-end marker, then a `null` element is appended to the array;
+        otherwise
+
+        - if the containing value is an @ref array, and the token represents a
+        number, then if the difference between the number and array's size
+        is smaller than `opts.max_created_elements`, then the size of the
+        array is increased, so that the number can reference an element in the
+        array; otherwise
+
+        - if the containing value is of different @ref kind and
+          `opts.replace_any_scalar` is `true`, or the value is `null`, then
+
+           - if `opts.create_arrays` is `true` and the token either represents
+             past-the-end marker or a number, then the value is replaced with
+             an empty array and the token is considered again; otherwise
+
+           - if `opts.create_objects` is `true`, then the value is replaced
+             with an empty object and the token is considered again; otherwise
+
+        - an error is produced.
+
+        @par Complexity
+        Linear in the sum of size of `ptr`, size of underlying array, object,
+        or string and `opts.max_created_elements`.
+
+        @par Exception Safety
+        Basic guarantee.
+        Calls to `memory_resource::allocate` may throw.
+
+        @param sv JSON Pointer string.
+
+        @param ref The value to assign to pointed element.
+
+        @param opts The options for the algorithm.
+
+        @return Reference to the element identified by `ptr`.
+
+        @see @ref set_pointer_options,
+        <a href="https://datatracker.ietf.org/doc/html/rfc6901">
+            RFC 6901 - JavaScript Object Notation (JSON) Pointer</a>.
+    */
+    BOOST_JSON_DECL
+    value&
+    set_at_pointer(
+        string_view sv,
+        value_ref ref,
+        set_pointer_options const& opts = {} );
+
+    /** Set an element via JSON Pointer.
+
+        This function is used to insert or assign to a potentially nested
+        element of the value using a JSON Pointer string. The function may
+        create intermediate elements corresponding to pointer segments.
+        <br/>
+
+        The particular conditions when and what kind of intermediate element
+        is created is governed by the `ptr` parameter.
+
+        Each pointer token is considered in sequence. For each token
+
+        - if the containing value is an @ref object, then a new `null`
+          element is created with key equal to unescaped token string;
+          otherwise
+
+        - if the containing value is an @ref array, and the token represents a
+          past-the-end marker, then a `null` element is appended to the array;
+          otherwise
+
+        - if the containing value is an @ref array, and the token represents a
+          number, then if the difference between the number and array's size
+          is smaller than `opts.max_created_elements`, then the size of the
+          array is increased, so that the number can reference an element in the
+          array; otherwise
+
+        - if the containing value is of different @ref kind and
+          `opts.replace_any_scalar` is `true`, or the value is `null`, then
+
+           - if `opts.create_arrays` is `true` and the token either represents
+             past-the-end marker or a number, then the value is replaced with
+             an empty array and the token is considered again; otherwise
+
+           - if `opts.create_objects` is `true`, then the value is replaced
+             with an empty object and the token is considered again; otherwise
+
+        - an error is produced.
+
+        @par Complexity
+        Linear in the sum of size of `ptr`, size of underlying array, object,
+        or string and `opts.max_created_elements`.
+
+        @par Exception Safety
+        Basic guarantee.
+        Calls to `memory_resource::allocate` may throw.
+
+        @param sv JSON Pointer string.
+
+        @param ref The value to assign to pointed element.
+
+        @param ec Set to the error, if any occurred.
+
+        @param opts The options for the algorithm.
+
+        @return Pointer to the element identified by `ptr`.
+
+        @see @ref set_pointer_options,
+        <a href="https://datatracker.ietf.org/doc/html/rfc6901">
+            RFC 6901 - JavaScript Object Notation (JSON) Pointer</a>.
+    */
+/** @{ */
+    BOOST_JSON_DECL
+    value*
+    set_at_pointer(
+        string_view sv,
+        value_ref ref,
+        error_code& ec,
+        set_pointer_options const& opts = {} );
+
+    BOOST_JSON_DECL
+    value*
+    set_at_pointer(
+        string_view sv,
+        value_ref ref,
+        std::error_code& ec,
+        set_pointer_options const& opts = {} );
+/** @} */
+
+    //------------------------------------------------------
 
     /** Return `true` if two values are equal.
 

--- a/test/snippets.cpp
+++ b/test/snippets.cpp
@@ -14,6 +14,7 @@
 #elif defined(__clang__)
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wunused"
+# pragma clang diagnostic ignored "-Wmismatched-tags"
 #elif defined(__GNUC__)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused"
@@ -769,6 +770,32 @@ usingPointer()
     assert( elem1 == elem2 );
 }
 
+
+void
+usingSetAtPointer()
+{
+    //[snippet_pointer_4
+    value jv;
+    jv.set_at_pointer("/two/bar/0", 12);
+    assert( jv.is_object() );
+    assert( jv.at_pointer("/two").is_object() );
+    assert( jv.at_pointer("/two/bar").is_array() );
+    assert( jv.at_pointer("/two/bar/0") == 12 );
+    //]
+
+    jv = nullptr;
+    //[snippet_pointer_5
+    set_pointer_options opts;
+    opts.create_arrays = false;
+
+    jv.set_at_pointer("/two/bar/0", 12, opts);
+    assert( jv.is_object() );
+    assert( jv.at_pointer("/two").is_object() );
+    assert( jv.at_pointer("/two/bar").is_object() ); // object, not array
+    assert( jv.at_pointer("/two/bar/0") == 12 );
+    //]
+}
+
 BOOST_STATIC_ASSERT(
     has_value_from<customer>::value);
 
@@ -836,6 +863,7 @@ public:
         usingStrings();
         usingPointer();
         usingSpecializedTrait();
+        usingSetAtPointer();
 
         BOOST_TEST_PASS();
     }


### PR DESCRIPTION
Fix #700

This implementation makes these choices:
1. Nulls are replaced when creating intermediaries.
2. When creating intermediaries segments are always treated as object keys, (that is only objects are created as intermediaries).
3. Arrays are extended by 1 element at most.