### PR TITLE
object::stable_erase

### DIFF
--- a/include/boost/json/object.hpp
+++ b/include/boost/json/object.hpp
@@ -1176,7 +1176,7 @@ public:
         References and iterators from `pos` to `end()`, both
         included, are invalidated. Other iterators and references
         are not invalidated.
-        The relative order of non-erased elements is preserved.
+        The relative order of remaining elements is preserved.
 
         @note
 
@@ -1202,7 +1202,7 @@ public:
 
         Remove the element which matches `key`, if it exists.
         All references and iterators are invalidated.
-        The relative order of non-erased elements is preserved.
+        The relative order of remaining elements is preserved.
 
         @par Complexity
         Linear in @ref size().
@@ -1620,6 +1620,14 @@ private:
     destroy(
         key_value_pair* first,
         key_value_pair* last) noexcept;
+
+    template<class FS, class FB>
+    auto
+    do_erase(
+        const_iterator pos,
+        FS small_reloc,
+        FB big_reloc) noexcept
+        -> iterator;
 
     inline
     void

--- a/include/boost/json/object.hpp
+++ b/include/boost/json/object.hpp
@@ -1172,7 +1172,9 @@ public:
         be valid and dereferenceable. Thus the @ref end()
         iterator (which is valid but cannot be dereferenced)
         cannot be used as a value for `pos`.
-        All references and iterators are invalidated.
+        References and iterators from `pos` to `end()`, both
+        included, are invalidated. Other iterators and references
+        are not invalidated.
         The relative order of non-erased elements is preserved.
 
         @par Complexity

--- a/include/boost/json/object.hpp
+++ b/include/boost/json/object.hpp
@@ -1166,6 +1166,51 @@ public:
     std::size_t
     erase(string_view key) noexcept;
 
+    /** Erase an element preserving order
+
+        Remove the element pointed to by `pos`, which must
+        be valid and dereferenceable. Thus the @ref end()
+        iterator (which is valid but cannot be dereferenced)
+        cannot be used as a value for `pos`.
+        All references and iterators are invalidated.
+        The relative order of non-erased elements is preserved.
+
+        @par Complexity
+        Linear in @ref size().
+
+        @par Exception Safety
+        No-throw guarantee.
+
+        @return An iterator following the last removed element.
+
+        @param pos An iterator pointing to the element to be
+        removed.
+    */
+    BOOST_JSON_DECL
+    iterator
+    stable_erase(const_iterator pos) noexcept;
+
+    /** Erase an element preserving order
+
+        Remove the element which matches `key`, if it exists.
+        All references and iterators are invalidated.
+        The relative order of non-erased elements is preserved.
+
+        @par Complexity
+        Linear in @ref size().
+
+        @par Exception Safety
+        No-throw guarantee.
+
+        @return The number of elements removed, which will
+        be either 0 or 1.
+
+        @param key The key to match.
+    */
+    BOOST_JSON_DECL
+    std::size_t
+    stable_erase(string_view key) noexcept;
+
     /** Swap two objects.
 
         Exchanges the contents of this object with another

--- a/include/boost/json/object.hpp
+++ b/include/boost/json/object.hpp
@@ -1612,6 +1612,12 @@ private:
     destroy(
         key_value_pair* first,
         key_value_pair* last) noexcept;
+
+    inline
+    void
+    reindex_relocate(
+        key_value_pair* src,
+        key_value_pair* dst) noexcept;
 };
 
 BOOST_JSON_NS_END

--- a/include/boost/json/object.hpp
+++ b/include/boost/json/object.hpp
@@ -1122,12 +1122,15 @@ public:
     /** Erase an element
 
         Remove the element pointed to by `pos`, which must
-        be valid and dereferenceable. Thus the @ref end()
-        iterator (which is valid but cannot be dereferenced)
-        cannot be used as a value for `pos`.
+        be valid and dereferenceable.
         References and iterators to the erased element are
         invalidated. Other iterators and references are not
         invalidated.
+
+        @note
+
+        The @ref end() iterator (which is valid but cannot be
+        dereferenced) cannot be used as a value for `pos`.
 
         @par Complexity
         Constant on average, worst case linear in @ref size().
@@ -1135,7 +1138,7 @@ public:
         @par Exception Safety
         No-throw guarantee.
 
-        @return An iterator following the last removed element.
+        @return An iterator following the removed element.
 
         @param pos An iterator pointing to the element to be
         removed.
@@ -1169,13 +1172,16 @@ public:
     /** Erase an element preserving order
 
         Remove the element pointed to by `pos`, which must
-        be valid and dereferenceable. Thus the @ref end()
-        iterator (which is valid but cannot be dereferenced)
-        cannot be used as a value for `pos`.
+        be valid and dereferenceable.
         References and iterators from `pos` to `end()`, both
         included, are invalidated. Other iterators and references
         are not invalidated.
         The relative order of non-erased elements is preserved.
+
+        @note
+
+        The @ref end() iterator (which is valid but cannot be
+        dereferenced) cannot be used as a value for `pos`.
 
         @par Complexity
         Linear in @ref size().
@@ -1183,7 +1189,7 @@ public:
         @par Exception Safety
         No-throw guarantee.
 
-        @return An iterator following the last removed element.
+        @return An iterator following the removed element.
 
         @param pos An iterator pointing to the element to be
         removed.

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -1204,6 +1204,62 @@ public:
             }
         }
 
+        // stable_erase(pos)
+        {
+            // small
+            {
+                object o(i0_);
+                auto it = o.stable_erase(o.find("10"));
+                BOOST_TEST(it->key() == "11");
+                BOOST_TEST(
+                    it->value().as_int64() == 11);
+                BOOST_TEST(serialize(o) ==
+                    R"({"0":0,"1":1,"2":2,"3":3,"4":4,)"
+                    R"("5":5,"6":6,"7":7,"8":8,"9":9,)"
+                    R"("11":11,"12":12,"13":13,"14":14,"15":15})");
+                BOOST_TEST(o.find("11") == it);
+                BOOST_TEST(o.find("14") == o.end() - 2);
+            }
+
+            // large
+            {
+                object o(i1_);
+                auto it = o.stable_erase(o.find("10"));
+                BOOST_TEST(it->key() == "11");
+                BOOST_TEST(
+                    it->value().as_int64() == 11);
+                BOOST_TEST(serialize(o) ==
+                    R"({"0":0,"1":1,"2":2,"3":3,"4":4,)"
+                    R"("5":5,"6":6,"7":7,"8":8,"9":9,)"
+                    R"("11":11,"12":12,"13":13,"14":14,"15":15,)"
+                    R"("16":16,"17":17,"18":18,"19":19})");
+                BOOST_TEST(o.find("11") == it);
+                BOOST_TEST(o.find("18") == o.end() - 2);
+            }
+        }
+
+        // stable_erase(key)
+        {
+            {
+                object o({
+                    {"a", 1},
+                    {"b", true},
+                    {"c", "hello"}});
+                BOOST_TEST(o.stable_erase("b2") == 0);
+                check(o, 3);
+            }
+
+            {
+                object o({
+                    {"a", 1},
+                    {"b", true},
+                    {"b2", 2},
+                    {"c", "hello"}});
+                BOOST_TEST(o.stable_erase("b2") == 1);
+                check(o, 4);
+            }
+        }
+
         // swap(object&)
         {
             {


### PR DESCRIPTION
Support for erasing an element without reordering. This is part one of support https://github.com/boostorg/json/issues/748, part two would be stable_insert.