### PR TITLE
Add README file in doc/ dir

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,11 @@
+## Instructions for Documentation
+
+Scripts to build the documentation can be found at https://github.com/boostorg/release-tools/tree/master/build_docs
+
+For example on a Linux system, copy the file `linuxdocs.sh` into the current directory and run it.
+
+```
+./linuxdocs.sh
+```
+
+The quickbook doc files are compiled into html format.


### PR DESCRIPTION
New scripts in https://github.com/boostorg/release-tools/tree/master/build_docs will compile and build the documentation (for any boost library, not only boostorg/json).