### PR TITLE
write double values with full precision in example pretty.cpp

### DIFF
--- a/example/pretty.cpp
+++ b/example/pretty.cpp
@@ -104,15 +104,9 @@ pretty_print( std::ostream& os, json::value const& jv, std::string* indent = nul
     }
 
     case json::kind::uint64:
-        os << jv.get_uint64();
-        break;
-
     case json::kind::int64:
-        os << jv.get_int64();
-        break;
-
     case json::kind::double_:
-        os << jv.get_double();
+        os << jv;
         break;
 
     case json::kind::bool_:


### PR DESCRIPTION
avoid precision issues with double values when parsing a pretty_printed JSON file

see my discussion with @grisumbras in https://github.com/boostorg/json/pull/33#discussion_r1055258619