### PR TITLE
Skip bench if dependencies are missing.

### DIFF
--- a/bench/Jamfile
+++ b/bench/Jamfile
@@ -7,9 +7,13 @@
 # Official repository: https://github.com/boostorg/json
 #
 
-exe bench :
-    bench.cpp
-    /boost/json//boost_json
-    :
-    <include>../test
-    ;
+if [ glob lib/nlohmann/single_include/nlohmann/json.hpp ]
+{
+    exe bench :
+        bench.cpp
+        /boost/json//boost_json
+        :
+        <include>../test
+        <include>.
+        ;
+}


### PR DESCRIPTION
If one exec b2 at the json-root without running the clone.sh script one will get header-not-found errors. This change prevents the bench from building when the required extra source files are not present.