### PR TITLE
Fix -Wdeprecated-declarations for sprintf

### DIFF
--- a/test/double.cpp
+++ b/test/double.cpp
@@ -32,7 +32,7 @@ sprintf(char (&buf)[N],
     sprintf_s(buf, format,
         std::forward<Args>(args)...);
 #else
-    std::sprintf(buf, format,
+    std::snprintf(buf, N, format,
         std::forward<Args>(args)...);
 #endif
 }


### PR DESCRIPTION
Clang issues `-Wdeprecated-declarations` warning for use of `sprintf`:

```
double.cpp:35:10: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
    std::sprintf(buf, format,
         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
```

Since we know the size simply replace `sprintf` with `snprintf`.