### PR TITLE
STL Charconv Integration

### DIFF
--- a/include/boost/json/detail/impl/format.ipp
+++ b/include/boost/json/detail/impl/format.ipp
@@ -11,8 +11,15 @@
 #ifndef BOOST_JSON_DETAIL_IMPL_FORMAT_IPP
 #define BOOST_JSON_DETAIL_IMPL_FORMAT_IPP
 
+#include <boost/json/detail/config.hpp>
 #include <boost/json/detail/ryu/ryu.hpp>
 #include <cstring>
+#include <cstdint>
+
+#ifndef BOOST_NO_CXX17_HDR_CHARCONV
+#  include <charconv>
+#  define BOOST_JSON_USE_CHARCONV
+#endif 
 
 namespace boost {
 namespace json {
@@ -97,6 +104,21 @@ format_uint64(
     return n;
 }
 
+#ifdef BOOST_JSON_USE_CHARCONV
+unsigned
+format_int64(
+    char* dest, int64_t i) noexcept
+{    
+    char buffer[21] {};
+    const auto r = std::to_chars(buffer, buffer + sizeof(buffer) - 1, i);
+    const std::ptrdiff_t n = r.ptr - buffer;
+
+    std::memcpy(dest, buffer, n);
+
+    return static_cast<unsigned>(n);
+}
+#else
+
 unsigned
 format_int64(
     char* dest, int64_t i) noexcept
@@ -109,6 +131,8 @@ format_int64(
     ui = ~ui + 1;
     return 1 + format_uint64(dest, ui);
 }
+
+#endif // Use charconv
 
 unsigned
 format_double(

--- a/include/boost/json/detail/impl/format.ipp
+++ b/include/boost/json/detail/impl/format.ipp
@@ -32,6 +32,24 @@ namespace detail {
     https://kkimdev.github.io/posts/2018/06/15/IEEE-754-Floating-Point-Type-in-C++.html
 */
 
+#ifdef BOOST_JSON_USE_CHARCONV
+
+unsigned
+format_uint64(
+    char* dest,
+    uint64_t i) noexcept
+{    
+    char buffer[21] {};
+    const auto r = std::to_chars(buffer, buffer + sizeof(buffer) - 1, i);
+    const std::ptrdiff_t n = r.ptr - buffer;
+
+    std::memcpy(dest, buffer, n);
+
+    return static_cast<unsigned>(n);
+}
+
+#else
+
 inline char const* digits_lut() noexcept
 {
     return
@@ -103,6 +121,8 @@ format_uint64(
 
     return n;
 }
+
+#endif // Use charconv
 
 #ifdef BOOST_JSON_USE_CHARCONV
 unsigned

--- a/include/boost/json/detail/impl/format.ipp
+++ b/include/boost/json/detail/impl/format.ipp
@@ -13,6 +13,7 @@
 
 #include <boost/json/detail/config.hpp>
 #include <boost/json/detail/ryu/ryu.hpp>
+#include <limits>
 #include <cstring>
 #include <cstdint>
 #include <cmath>
@@ -74,13 +75,9 @@ format_uint64(
     char* dest,
     uint64_t i) noexcept
 {    
-    char buffer[21] {};
-    const auto r = std::to_chars(buffer, buffer + sizeof(buffer) - 1, i);
-    const std::ptrdiff_t n = r.ptr - buffer;
-
-    std::memcpy(dest, buffer, n);
-
-    return static_cast<unsigned>(n);
+    static constexpr auto u64_max_chars = std::numeric_limits<uint64_t>::digits10 + 1;
+    const auto r = std::to_chars(dest, dest + u64_max_chars, i);
+    return static_cast<unsigned>(r.ptr - dest);
 }
 
 #else
@@ -164,13 +161,9 @@ unsigned
 format_int64(
     char* dest, int64_t i) noexcept
 {    
-    char buffer[21] {};
-    const auto r = std::to_chars(buffer, buffer + sizeof(buffer) - 1, i);
-    const std::ptrdiff_t n = r.ptr - buffer;
-
-    std::memcpy(dest, buffer, n);
-
-    return static_cast<unsigned>(n);
+    static constexpr auto i64_max_chars = std::numeric_limits<int64_t>::digits10 + 2;
+    const auto r = std::to_chars(dest, dest + i64_max_chars, i);
+    return static_cast<unsigned>(r.ptr - dest);
 }
 #else
 
@@ -211,13 +204,8 @@ format_double(
         }
     }
 
-    char buffer[max_number_chars] {};
-    const auto r = std::to_chars(buffer, buffer + sizeof(buffer) - 1, d, std::chars_format::scientific);
-    const std::ptrdiff_t n = r.ptr - buffer;
-
-    std::memcpy(dest, buffer, n);
-
-    return static_cast<unsigned>(n);
+    const auto r = std::to_chars(dest, dest + max_number_chars, d, std::chars_format::scientific);
+    return static_cast<unsigned>(r.ptr - dest);
 }
 
 #else

--- a/include/boost/json/detail/impl/format.ipp
+++ b/include/boost/json/detail/impl/format.ipp
@@ -114,7 +114,7 @@ unsigned
 format_double(
     char* dest, double d) noexcept
 {
-    return static_cast<int>(
+    return static_cast<unsigned>(
         ryu::d2s_buffered_n(d, dest));
 }
 


### PR DESCRIPTION
Use the STL implementations of `<charconv>` when available. Integers are pretty well supported, but floating points are not.