### PR TITLE
Feature: serialize special numbers

### DIFF
--- a/doc/qbk/quickref.xml
+++ b/doc/qbk/quickref.xml
@@ -28,6 +28,7 @@
           <member><link linkend="json.ref.boost__json__parser">parser</link></member>
           <member><link linkend="json.ref.boost__json__parse_options">parse_options</link></member>
           <member><link linkend="json.ref.boost__json__serializer">serializer</link></member>
+          <member><link linkend="json.ref.boost__json__serialize_options">serialize_options</link></member>
           <member><link linkend="json.ref.boost__json__set_pointer_options">set_pointer_options</link></member>
           <member><link linkend="json.ref.boost__json__static_resource">static_resource</link></member>
           <member><link linkend="json.ref.boost__json__storage_ptr">storage_ptr</link></member>

--- a/include/boost/json/detail/format.hpp
+++ b/include/boost/json/detail/format.hpp
@@ -35,7 +35,7 @@ format_int64(
 BOOST_JSON_DECL
 unsigned
 format_double(
-    char* dest, double d) noexcept;
+    char* dest, double d, bool allow_infinity_and_nan = false) noexcept;
 
 } // detail
 } // namespace json

--- a/include/boost/json/detail/impl/format.ipp
+++ b/include/boost/json/detail/impl/format.ipp
@@ -112,10 +112,10 @@ format_int64(
 
 unsigned
 format_double(
-    char* dest, double d) noexcept
+    char* dest, double d, bool allow_infinity_and_nan) noexcept
 {
     return static_cast<int>(
-        ryu::d2s_buffered_n(d, dest));
+        ryu::d2s_buffered_n(d, dest, allow_infinity_and_nan));
 }
 
 } // detail

--- a/include/boost/json/detail/ryu/detail/common.hpp
+++ b/include/boost/json/detail/ryu/detail/common.hpp
@@ -98,6 +98,30 @@ inline int copy_special_str(char * const result, const bool sign, const bool exp
   return sign + 3;
 }
 
+inline
+int
+copy_special_str_conforming(
+    char* const result, bool sign, bool exponent, bool mantissa)
+{
+  if (mantissa)
+  {
+    memcpy(result, "null", 4);
+    return 4;
+  }
+
+  if (sign)
+    result[0] = '-';
+
+  if (exponent)
+  {
+    memcpy(result + sign, "1e99999", 7);
+    return sign + 7;
+  }
+
+  memcpy(result + sign, "0E0", 3);
+  return sign + 3;
+}
+
 inline uint32_t float_to_bits(const float f) {
   uint32_t bits = 0;
   memcpy(&bits, &f, sizeof(float));

--- a/include/boost/json/detail/ryu/impl/d2s.ipp
+++ b/include/boost/json/detail/ryu/impl/d2s.ipp
@@ -671,7 +671,8 @@ static inline bool d2d_small_int(const uint64_t ieeeMantissa, const uint32_t iee
 int
 d2s_buffered_n(
     double f,
-    char* result) noexcept
+    char* result,
+    bool allow_infinity_and_nan) noexcept
 {
     using namespace detail;
     // Step 1: Decode the floating-point number, and unify normalized and subnormal cases.
@@ -691,7 +692,12 @@ d2s_buffered_n(
     const std::uint32_t ieeeExponent = (std::uint32_t)((bits >> DOUBLE_MANTISSA_BITS) & ((1u << DOUBLE_EXPONENT_BITS) - 1));
     // Case distinction; exit early for the easy cases.
     if (ieeeExponent == ((1u << DOUBLE_EXPONENT_BITS) - 1u) || (ieeeExponent == 0 && ieeeMantissa == 0)) {
-        return copy_special_str(result, ieeeSign, ieeeExponent != 0, ieeeMantissa != 0);
+        // We changed how special numbers are output by default
+        if (allow_infinity_and_nan)
+            return copy_special_str(result, ieeeSign, ieeeExponent != 0, ieeeMantissa != 0);
+        else
+            return copy_special_str_conforming(result, ieeeSign, ieeeExponent != 0, ieeeMantissa != 0);
+
     }
 
     floating_decimal_64 v;

--- a/include/boost/json/detail/ryu/ryu.hpp
+++ b/include/boost/json/detail/ryu/ryu.hpp
@@ -31,7 +31,8 @@ namespace detail {
 namespace ryu {
 
 BOOST_JSON_DECL
-int d2s_buffered_n(double f, char* result) noexcept;
+int d2s_buffered_n(
+    double f, char* result, bool allow_infinity_and_nan = true) noexcept;
 
 } // ryu
 

--- a/include/boost/json/impl/serialize.ipp
+++ b/include/boost/json/impl/serialize.ipp
@@ -17,6 +17,39 @@
 namespace boost {
 namespace json {
 
+namespace {
+
+int serialize_xalloc = std::ios::xalloc();
+
+enum class serialize_stream_flags : long
+{
+    allow_infinity_and_nan = 1,
+};
+
+std::underlying_type<serialize_stream_flags>::type
+to_bitmask( serialize_options const& opts )
+{
+    using E = serialize_stream_flags;
+    using I = std::underlying_type<E>::type;
+    return (opts.allow_infinity_and_nan
+        ? static_cast<I>(E::allow_infinity_and_nan) : 0);
+}
+
+serialize_options
+get_stream_flags( std::ostream& os )
+{
+    auto const flags = os.iword(serialize_xalloc);
+
+    serialize_options opts;
+    using E = serialize_stream_flags;
+    using I = std::underlying_type<E>::type;
+    opts.allow_infinity_and_nan =
+        flags & static_cast<I>(E::allow_infinity_and_nan);
+    return opts;
+}
+
+} // namespace
+
 static
 void
 serialize_impl(
@@ -147,7 +180,7 @@ std::ostream&
 operator<<( std::ostream& os, value const& jv )
 {
     // Create a serializer
-    serializer sr;
+    serializer sr( get_stream_flags(os) );
 
     // Set the serializer up for our value
     sr.reset( &jv );
@@ -185,7 +218,7 @@ operator<<(
     std::ostream& os,
     array const& arr)
 {
-    serializer sr;
+    serializer sr( get_stream_flags(os) );
     sr.reset(&arr);
     to_ostream(os, sr);
     return os;
@@ -196,7 +229,7 @@ operator<<(
     std::ostream& os,
     object const& obj)
 {
-    serializer sr;
+    serializer sr( get_stream_flags(os) );
     sr.reset(&obj);
     to_ostream(os, sr);
     return os;
@@ -207,9 +240,16 @@ operator<<(
     std::ostream& os,
     string const& str)
 {
-    serializer sr;
+    serializer sr( get_stream_flags(os) );
     sr.reset(&str);
     to_ostream(os, sr);
+    return os;
+}
+
+std::ostream&
+operator<<( std::ostream& os, serialize_options const& opts )
+{
+    os.iword(serialize_xalloc) = to_bitmask(opts);
     return os;
 }
 

--- a/include/boost/json/impl/serialize.ipp
+++ b/include/boost/json/impl/serialize.ipp
@@ -63,13 +63,15 @@ serialize_impl(
 
 std::string
 serialize(
-    value const& jv)
+    value const& jv,
+    serialize_options const& opts)
 {
     unsigned char buf[256];
     serializer sr(
         storage_ptr(),
         buf,
-        sizeof(buf));
+        sizeof(buf),
+        opts);
     sr.reset(&jv);
     std::string s;
     serialize_impl(s, sr);
@@ -78,13 +80,15 @@ serialize(
 
 std::string
 serialize(
-    array const& arr)
+    array const& arr,
+    serialize_options const& opts)
 {
     unsigned char buf[256];
     serializer sr(
         storage_ptr(),
         buf,
-        sizeof(buf));
+        sizeof(buf),
+        opts);
     std::string s;
     sr.reset(&arr);
     serialize_impl(s, sr);
@@ -93,13 +97,15 @@ serialize(
 
 std::string
 serialize(
-    object const& obj)
+    object const& obj,
+    serialize_options const& opts)
 {
     unsigned char buf[256];
     serializer sr(
         storage_ptr(),
         buf,
-        sizeof(buf));
+        sizeof(buf),
+        opts);
     std::string s;
     sr.reset(&obj);
     serialize_impl(s, sr);
@@ -108,21 +114,24 @@ serialize(
 
 std::string
 serialize(
-    string const& str)
+    string const& str,
+    serialize_options const& opts)
 {
-    return serialize( str.subview() );
+    return serialize( str.subview(), opts );
 }
 
 // this is here for key_value_pair::key()
 std::string
 serialize(
-    string_view sv)
+    string_view sv,
+    serialize_options const& opts)
 {
     unsigned char buf[256];
     serializer sr(
         storage_ptr(),
         buf,
-        sizeof(buf));
+        sizeof(buf),
+        opts);
     std::string s;
     sr.reset(sv);
     serialize_impl(s, sr);

--- a/include/boost/json/impl/serializer.ipp
+++ b/include/boost/json/impl/serializer.ipp
@@ -44,11 +44,13 @@ serializer::
 serializer(
     storage_ptr sp,
     unsigned char* buf,
-    std::size_t buf_size) noexcept
+    std::size_t buf_size,
+    serialize_options const& opts) noexcept
     : st_(
         std::move(sp),
         buf,
         buf_size)
+    , opts_(opts)
 {
 }
 
@@ -437,12 +439,15 @@ write_number(stream& ss0)
                 ss.remain() >=
                     detail::max_number_chars))
             {
-                ss.advance(detail::format_double(
-                    ss.data(), jv_->get_double()));
+                ss.advance(
+                    detail::format_double(
+                        ss.data(),
+                        jv_->get_double(),
+                        opts_.allow_infinity_and_nan));
                 return true;
             }
             cs0_ = { buf_, detail::format_double(
-                buf_, jv_->get_double()) };
+                buf_, jv_->get_double(), opts_.allow_infinity_and_nan) };
             break;
         }
     }
@@ -750,7 +755,8 @@ read_some(
 //----------------------------------------------------------
 
 serializer::
-serializer() noexcept
+serializer( serialize_options const& opts ) noexcept
+    : opts_(opts)
 {
     // ensure room for \uXXXX escape plus one
     BOOST_STATIC_ASSERT(

--- a/include/boost/json/serialize.hpp
+++ b/include/boost/json/serialize.hpp
@@ -35,7 +35,7 @@ namespace json {
 
     @param t The value to serialize
 
-    @param opt The options for the serializer. If this parameter
+    @param opts The options for the serializer. If this parameter
     is omitted, the serializer will output only standard JSON.
 */
 /** @{ */

--- a/include/boost/json/serialize.hpp
+++ b/include/boost/json/serialize.hpp
@@ -11,6 +11,7 @@
 #define BOOST_JSON_SERIALIZE_HPP
 
 #include <boost/json/detail/config.hpp>
+#include <boost/json/serialize_options.hpp>
 #include <boost/json/value.hpp>
 #include <iosfwd>
 #include <string>
@@ -33,27 +34,30 @@ namespace json {
     @return The serialized string
 
     @param t The value to serialize
+
+    @param opt The options for the serializer. If this parameter
+    is omitted, the serializer will output only standard JSON.
 */
 /** @{ */
 BOOST_JSON_DECL
 std::string
-serialize(value const& t);
+serialize(value const& t, serialize_options const& opts = {});
 
 BOOST_JSON_DECL
 std::string
-serialize(array const& t);
+serialize(array const& t, serialize_options const& opts = {});
 
 BOOST_JSON_DECL
 std::string
-serialize(object const& t);
+serialize(object const& t, serialize_options const& opts = {});
 
 BOOST_JSON_DECL
 std::string
-serialize(string const& t);
+serialize(string const& t, serialize_options const& opts = {});
 
 BOOST_JSON_DECL
 std::string
-serialize(string_view t);
+serialize(string_view t, serialize_options const& opts = {});
 /** @} */
 
 } // namespace json

--- a/include/boost/json/serialize_options.hpp
+++ b/include/boost/json/serialize_options.hpp
@@ -11,6 +11,7 @@
 #define BOOST_JSON_SERIALIZE_OPTIONS_HPP
 
 #include <boost/json/detail/config.hpp>
+#include <iosfwd>
 
 namespace boost {
 namespace json {
@@ -37,6 +38,30 @@ struct serialize_options
             @ref serializer.
     */
     bool allow_infinity_and_nan = false;
+
+    /** Set JSON serialization options on input stream.
+        The function stores serialization options in the private storage of the
+        stream. If the stream fails to allocate necessary private storage,
+        `badbit` will be set on it.
+
+        @return Reference to `os`.
+
+        @par Complexity
+        Amortized constant (due to potential memory allocation by the stream).
+
+        @par Exception Safety
+        Strong guarantee.
+        The stream may throw as configured by
+        [`std::ios::exceptions`](https://en.cppreference.com/w/cpp/io/basic_ios/exceptions).
+
+        @param os The output stream.
+
+        @param opts The options to store.
+    */
+    BOOST_JSON_DECL
+    friend
+    std::ostream&
+    operator<<( std::ostream& os, serialize_options const& opts );
 };
 
 } // namespace json

--- a/include/boost/json/serialize_options.hpp
+++ b/include/boost/json/serialize_options.hpp
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2023 Dmitry Arkhipov (grisumbras@yandex.ru)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/json
+//
+
+#ifndef BOOST_JSON_SERIALIZE_OPTIONS_HPP
+#define BOOST_JSON_SERIALIZE_OPTIONS_HPP
+
+#include <boost/json/detail/config.hpp>
+
+namespace boost {
+namespace json {
+
+/** Serialize options
+
+    This structure is used for specifying whether to allow non-standard
+    extensions. Default-constructed options specify that only standard JSON is
+    produced.
+
+    @see
+        @ref serialize,
+        @ref serializer.
+*/
+struct serialize_options
+{
+    /** Non-standard extension option
+
+        Output `Infinity`, `-Infinity` and `NaN` for positive infinity,
+        negative infinity, and "not a number" doubles.
+
+        @see
+            @ref serialize,
+            @ref serializer.
+    */
+    bool allow_infinity_and_nan = false;
+};
+
+} // namespace json
+} // namespace boost
+
+#endif // BOOST_JSON_SERIALIZE_OPTIONS_HPP

--- a/include/boost/json/serializer.hpp
+++ b/include/boost/json/serializer.hpp
@@ -11,10 +11,11 @@
 #define BOOST_JSON_SERIALIZER_HPP
 
 #include <boost/json/detail/config.hpp>
-#include <boost/json/value.hpp>
 #include <boost/json/detail/format.hpp>
 #include <boost/json/detail/stack.hpp>
 #include <boost/json/detail/stream.hpp>
+#include <boost/json/serialize_options.hpp>
+#include <boost/json/value.hpp>
 
 namespace boost {
 namespace json {
@@ -79,6 +80,7 @@ class serializer
     value const* jv_ = nullptr;
     detail::stack st_;
     const_stream cs0_;
+    serialize_options opts_;
     char buf_[detail::max_number_chars + 1];
     bool done_ = false;
 
@@ -126,9 +128,12 @@ public:
 
         @par Exception Safety
         No-throw guarantee.
+
+        @param opt The options for the serializer. If this parameter
+        is omitted, the serializer will output only standard JSON.
     */
     BOOST_JSON_DECL
-    serializer() noexcept;
+    serializer( serialize_options const& opts = {} ) noexcept;
 
     /** Constructor
 
@@ -155,12 +160,16 @@ public:
 
         @param buf_size The number of bytes of
         valid memory pointed to by `buf`.
+
+        @param opt The options for the serializer. If this parameter
+        is omitted, the serializer will output only standard JSON.
     */
     BOOST_JSON_DECL
     serializer(
         storage_ptr sp,
         unsigned char* buf = nullptr,
-        std::size_t buf_size = 0) noexcept;
+        std::size_t buf_size = 0,
+        serialize_options const& opts = {}) noexcept;
 
     /** Returns `true` if the serialization is complete
 

--- a/include/boost/json/serializer.hpp
+++ b/include/boost/json/serializer.hpp
@@ -129,7 +129,7 @@ public:
         @par Exception Safety
         No-throw guarantee.
 
-        @param opt The options for the serializer. If this parameter
+        @param opts The options for the serializer. If this parameter
         is omitted, the serializer will output only standard JSON.
     */
     BOOST_JSON_DECL
@@ -161,7 +161,7 @@ public:
         @param buf_size The number of bytes of
         valid memory pointed to by `buf`.
 
-        @param opt The options for the serializer. If this parameter
+        @param opts The options for the serializer. If this parameter
         is omitted, the serializer will output only standard JSON.
     */
     BOOST_JSON_DECL

--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -65,10 +65,20 @@ public:
         value const jv = {
             Lims::quiet_NaN(), Lims::infinity(), -Lims::infinity() };
         BOOST_TEST( serialize(jv) == "[null,1e99999,-1e99999]" );
+        BOOST_TEST( print(jv) == "[null,1e99999,-1e99999]" );
 
         serialize_options opts;
         opts.allow_infinity_and_nan = true;
         BOOST_TEST( serialize(jv, opts) == "[NaN,Infinity,-Infinity]" );
+
+        std::stringstream ss;
+        ss << opts << jv;
+        BOOST_TEST( ss.str() == "[NaN,Infinity,-Infinity]" );
+
+        opts.allow_infinity_and_nan = false;
+        ss.str("");
+        ss << opts << jv;
+        BOOST_TEST( ss.str() == "[null,1e99999,-1e99999]" );
     }
 
     void

--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/json/parse.hpp>
 #include <boost/json/static_resource.hpp>
+#include <limits>
 #include <sstream>
 
 #include "test_suite.hpp"
@@ -58,9 +59,23 @@ public:
     }
 
     void
+    testSpecialNumbers()
+    {
+        using Lims = std::numeric_limits<double>;
+        value const jv = {
+            Lims::quiet_NaN(), Lims::infinity(), -Lims::infinity() };
+        BOOST_TEST( serialize(jv) == "[null,1e99999,-1e99999]" );
+
+        serialize_options opts;
+        opts.allow_infinity_and_nan = true;
+        BOOST_TEST( serialize(jv, opts) == "[NaN,Infinity,-Infinity]" );
+    }
+
+    void
     run()
     {
         testSerialize();
+        testSpecialNumbers();
     }
 };
 


### PR DESCRIPTION
1. Change serializer to output special floating point numbers differently, so that the output is always valid JSON.
    * Infinity is output as `1e99999` (this number is so big that it is parsed by every implementation I am aware of as FP infinity).
    * NaN is output as `null`. It changes the type, and roundtrip won't happen, but at least it's not something that is not JSON.
2. Add serializer option to enable an extension (the extension is incidentally the current behaviour)
    * Infinity is output as `Infinity`.
    * NaN is output as `NaN`.
3. Add the ability to control serialisation options when outputting into ostreams.

The benefit for the second behaviour is that infinity and NaN are using unambiguous special representation.