### PR TITLE
Precise mode for parsing numbers

### DIFF
--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -53,6 +53,7 @@ using clock_type = std::chrono::steady_clock;
 
 ::test_suite::debug_stream dout(std::cerr);
 std::stringstream strout;
+parse_options popts;
 
 #if defined(__clang__)
 string_view toolset = "clang";
@@ -276,7 +277,7 @@ public:
         string_view s,
         std::size_t repeat) const override
     {
-        stream_parser p;
+        stream_parser p({}, popts);
         while(repeat--)
         {
             p.reset();
@@ -343,7 +344,7 @@ public:
         string_view s,
         std::size_t repeat) const override
     {
-        stream_parser p;
+        stream_parser p({}, popts);
         while(repeat--)
         {
             monotonic_resource mr;
@@ -422,7 +423,7 @@ class boost_null_impl : public any_impl
         basic_parser<handler> p_;
 
         null_parser()
-            : p_(json::parse_options())
+            : p_(popts)
         {
         }
 
@@ -514,7 +515,7 @@ public:
         while(repeat--)
         {
             error_code ec;
-            auto jv = json::parse(s, ec);
+            auto jv = json::parse(s, ec, {}, popts);
             (void)jv;
         }
     }
@@ -667,6 +668,12 @@ static bool parse_option( char const * s )
 
     char opt = *s++;
 
+    if( opt == 'p' )
+    {
+        popts.precise_parsing = true;
+        return *s == 0;
+    }
+
     if( *s++ != ':' )
     {
         return false;
@@ -810,6 +817,7 @@ main(
 			"                                 (default all)\n"
             "          -n:<number>          Number of trials (default 6)\n"
             "          -b:<branch>          Branch label for boost implementations\n"
+            "          -p                   Enable precise parsing\n"
         ;
 
         return 4;

--- a/doc/qbk/io/parsing.qbk
+++ b/doc/qbk/io/parsing.qbk
@@ -109,6 +109,24 @@ with __parse_options__ is possible:
 
 [/-----------------------------------------------------------------------------]
 
+[heading Full precision number parsing]
+
+The default algorithm that the library uses to parse numbers is fast, but may
+result in slight precision loss. This may not be suitable for some
+applications, so there is an option to enable an alternative algorithm that
+doesn't have that flaw, but is somewhat slower. To do this, you also need to
+use __parse_options__ structure.
+
+[doc_parsing_precise]
+
+Note that full precision number parsing requires the algorithm to see the full
+number. This means, that when used with __stream_parser__, additional memory
+allocations may be necessary to store the number parts which were so far
+accepted by the parser. The library does try its best to avoid such
+allocations.
+
+[/-----------------------------------------------------------------------------]
+
 [heading Parser]
 
 Instances of __parser__ and __stream_parser__ offer functionality beyond

--- a/include/boost/json/basic_parser.hpp
+++ b/include/boost/json/basic_parser.hpp
@@ -19,6 +19,7 @@
 #include <boost/json/detail/stack.hpp>
 #include <boost/json/detail/stream.hpp>
 #include <boost/json/detail/utf8.hpp>
+#include <boost/json/detail/sbo_buffer.hpp>
 
 namespace boost {
 namespace json {
@@ -304,6 +305,7 @@ class basic_parser
     bool done_ = false; // true on complete parse
     bool clean_ = true; // write_some exited cleanly
     const char* end_;
+    detail::sbo_buffer<16 + 16 + 1 + 1> num_buf_;
     parse_options opt_;
     // how many levels deeper the parser can go
     std::size_t depth_ = opt_.max_depth;

--- a/include/boost/json/detail/sbo_buffer.hpp
+++ b/include/boost/json/detail/sbo_buffer.hpp
@@ -1,0 +1,186 @@
+//
+// Copyright (c) 2023 Dmitry Arkhipov (grisumbras@yandex.ru)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/json
+//
+
+
+#ifndef BOOST_JSON_DETAIL_SBO_BUFFER_HPP
+#define BOOST_JSON_DETAIL_SBO_BUFFER_HPP
+
+#include <boost/json/detail/config.hpp>
+#include <boost/json/detail/except.hpp>
+#include <string>
+#include <array>
+
+namespace boost {
+namespace json {
+namespace detail {
+
+template< std::size_t N >
+class sbo_buffer
+{
+    struct size_ptr_pair
+    {
+        std::size_t size;
+        char* ptr;
+    };
+    BOOST_STATIC_ASSERT( N >= sizeof(size_ptr_pair) );
+
+    union {
+        std::array<char, N> buffer_;
+        std::size_t capacity_;
+    };
+    char* data_ = buffer_.data();
+    std::size_t size_ = 0;
+
+    bool
+    is_small() const noexcept
+    {
+        return data_ == buffer_.data();
+    }
+
+    void
+    dispose()
+    {
+        if( is_small() )
+            return;
+
+        delete[] data_;
+#if defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+        buffer_ = {};
+#if defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif
+        data_ = buffer_.data();
+    }
+
+    static constexpr
+    std::size_t
+    max_size() noexcept
+    {
+        return BOOST_JSON_MAX_STRING_SIZE;
+    }
+
+public:
+    sbo_buffer()
+        : buffer_()
+    {}
+
+    sbo_buffer( sbo_buffer&& other ) noexcept
+        : size_(other.size_)
+    {
+        if( other.is_small() )
+        {
+            buffer_ = other.buffer_;
+            data_ = buffer_.data();
+        }
+        else
+        {
+            data_ = other.data_;
+            other.data_ = other.buffer_.data();
+        }
+        BOOST_ASSERT( other.is_small() );
+    }
+
+    sbo_buffer&
+    operator=( sbo_buffer&& other ) noexcept
+    {
+        if( &other == this )
+            return this;
+
+        if( other.is_small() )
+        {
+            buffer_ = other.buffer_;
+            data_ = buffer_.data();
+        }
+        else
+        {
+            data_ = other.data_;
+            other.data_ = other.buffer_.data();
+        }
+
+        size_ = other.size_;
+        other.size_ = 0;
+
+        return *this;
+    }
+
+    ~sbo_buffer()
+    {
+        if( !is_small() )
+            delete[] data_;
+    }
+
+    std::size_t
+    capacity() const noexcept
+    {
+        return is_small() ? buffer_.size() : capacity_;
+    }
+
+    void
+    reset() noexcept
+    {
+        dispose();
+        clear();
+    }
+
+    void
+    clear()
+    {
+        size_ = 0;
+    }
+
+    void
+    grow( std::size_t size )
+    {
+        if( !size )
+            return;
+
+        if( max_size() - size_ < size )
+            detail::throw_length_error( "buffer too large" );
+
+        std::size_t const old_capacity = this->capacity();
+        std::size_t new_capacity = size_ + size;
+
+        // growth factor 2
+        if( old_capacity <= max_size() - old_capacity ) // check for overflow
+            new_capacity = (std::max)(old_capacity * 2, new_capacity);
+
+        char* new_data = new char[new_capacity];
+        std::memcpy(new_data, data_, size_);
+
+        dispose();
+        data_ = new_data;
+        capacity_ = new_capacity;
+    }
+
+    char*
+    append( char const* ptr, std::size_t size )
+    {
+        grow(size);
+
+        if(BOOST_JSON_LIKELY( size ))
+            std::memcpy( data_ + size_, ptr, size );
+        size_ += size;
+        return data_;
+    }
+
+    std::size_t
+    size() noexcept
+    {
+        return size_;
+    }
+};
+
+} // namespace detail
+} // namespace json
+} // namespace boost
+
+#endif // BOOST_JSON_DETAIL_SBO_BUFFER_HPP

--- a/include/boost/json/parse_options.hpp
+++ b/include/boost/json/parse_options.hpp
@@ -43,6 +43,16 @@ struct parse_options
     */
     std::size_t max_depth = 32;
 
+    /** Number prasing mode
+
+        This selects enables precise parsing at the cost of performance.
+
+        @see
+            @ref basic_parser,
+            @ref stream_parser.
+    */
+    bool precise_parsing = false;
+
     /** Non-standard extension option
 
         Allow C and C++ style comments to appear

--- a/test/doc_parsing.cpp
+++ b/test/doc_parsing.cpp
@@ -274,6 +274,20 @@ void do_rpc( string_view s, Handler&& handler )
 
 //----------------------------------------------------------
 
+void
+testPrecise()
+{
+    //[doc_parsing_precise
+    parse_options opt;
+    opt.precise_parsing = true;
+    value jv = parse( "1002.9111801605201", storage_ptr(), opt );
+    //]
+    (void)jv;
+    assert( jv == 1002.9111801605201 );
+}
+
+//----------------------------------------------------------
+
 class doc_parsing_test
 {
 public:
@@ -300,6 +314,8 @@ public:
             assert(( jvs[4] == array{2} ));
             assert(( jvs[5] == 3 ));
         }
+
+        testPrecise();
     }
 };
 

--- a/test/limits.cpp
+++ b/test/limits.cpp
@@ -377,6 +377,28 @@ public:
     }
 
     void
+    testNumber()
+    {
+        // very long floating point number
+        std::array<char, string::max_size()> buffer;
+        buffer.fill('0');
+        buffer.data()[1] = '.';
+
+        error_code ec;
+        parse_options precise;
+        precise.precise_parsing = true;
+        BOOST_TEST_THROWS(
+            parse( {buffer.data(), buffer.size()}, ec, {}, precise ),
+            std::length_error);
+        BOOST_TEST( !ec );
+
+        // now we make the number one character shorter
+        auto jv = parse( {buffer.data(), buffer.size() - 1}, ec, {}, precise );
+        BOOST_TEST( !ec );
+        BOOST_TEST( jv.as_double() == 0 );
+    }
+
+    void
     run()
     {
     #if ! defined(BOOST_JSON_NO_MAX_STRUCTURED_SIZE) && \
@@ -389,6 +411,7 @@ public:
         testArray();
         testString();
         testParser();
+        testNumber();
 
     #else
         BOOST_TEST_PASS();


### PR DESCRIPTION
This is technically a fix to #599, but we want a better implementation than `strtod` (because it is very slow). Closer to the release I'll take some files from Charconv.