### PR TITLE
fix reading beyond input buffer

### DIFF
--- a/include/boost/json/basic_parser.hpp
+++ b/include/boost/json/basic_parser.hpp
@@ -280,7 +280,7 @@ class basic_parser
         num1,  num2,  num3,  num4,
         num5,  num6,  num7,  num8,
         exp1,  exp2,  exp3,
-        val1,  val2
+        val1,  val2, val3
     };
 
     struct number

--- a/include/boost/json/basic_parser_impl.hpp
+++ b/include/boost/json/basic_parser_impl.hpp
@@ -785,7 +785,15 @@ resume_value(const char* p,
         p = parse_comment(p, std::false_type(), std::false_type());
         if(BOOST_JSON_UNLIKELY(p == sentinel()))
             return maybe_suspend(p, state::val2);
+        if(BOOST_JSON_UNLIKELY( p == end_ ))
+            return maybe_suspend(p, state::val3);
         BOOST_ASSERT(st_.empty());
+        return parse_value(p, std::true_type(), std::true_type(), allow_trailing, allow_bad_utf8);
+    }
+
+    case state::val3:
+    {
+        st_.pop(st);
         return parse_value(p, std::true_type(), std::true_type(), allow_trailing, allow_bad_utf8);
     }
     }

--- a/test/basic_parser.cpp
+++ b/test/basic_parser.cpp
@@ -1109,6 +1109,20 @@ public:
 
         // no newline at EOF
         TEST_GOOD_EXT("1//", enabled);
+
+        {
+            parse_options po;
+            po.allow_comments = true;
+            fail_parser p(po);
+            error_code ec;
+            p.write(true, "//", 2, ec); // suspend while inside comment
+            BOOST_TEST( !ec.failed() );
+            p.write(true, " \n1", 2, ec); // input ends comment,
+                                          // number starts after current input
+            BOOST_TEST( !ec.failed() );
+            p.write(false, "1", 1, ec);
+            BOOST_TEST( !ec.failed() );
+        }
     }
 
     void


### PR DESCRIPTION
This fixes a rare case when the parser first suspends inside a comment, then is given input exactly up to the newline character. Before the fix it proceeded to read past the end of the buffer or hit an assert.