### PR TITLE
Specify output location of bench executable

### DIFF
--- a/bench/Jamfile
+++ b/bench/Jamfile
@@ -28,4 +28,5 @@ exe bench :
     <include>../test
     $(has_nlohmann_json)<define>BOOST_JSON_HAS_NLOHMANN_JSON
     $(has_rapidjson)<define>BOOST_JSON_HAS_RAPIDJSON
+    : <location>.//bin.v2
     ;


### PR DESCRIPTION
This will build the benchmark executable as` ./bin.v2/bench` instead of `bin.v2/libs/json/bench/clang-linux-14/release/cxxstd-20-iso/link-static/bench`. By outputting the exe in the same place each time (similar to how b2 generates it's own file as `./b2`) it is easier to find and won't change later.  

It would be more convenient if the output locations were ` ./bin.v2/clang/bench` and ` ./bin.v2/gcc/bench`.  That requires knowing the 'toolset'.  Interestingly from the faqs, "How do I get the current value of feature in Jamfile? This is not possible, since Jamfile does not have "current" value of any feature, be it toolset, build variant or anything else. " $(toolset) doesn't have a value.  We can't define the output location to be  ` ./bin.v2/$(toolset)/bench`

After merging this into develop branch `runbenchmarks.py` will break.   I will need to modify the script, manually copy `bench` into ` ./bin.v2/clang/bench` and ` ./bin.v2/gcc/bench`, and run benchmarks from there.  @grisumbras if it looks ok, go ahead and merge.