### PR TITLE
b2 features for benchmarking are in separate module

### DIFF
--- a/bench/Jamfile
+++ b/bench/Jamfile
@@ -11,14 +11,11 @@ import common ;
 import os ;
 import path ;
 import property ;
+import bench.jam ;
 
 import feature ;
 
 path-constant HERE : . ;
-
-feature.feature bench.option : : free optional ;
-feature.feature bench.launcher : : free optional ;
-feature.feature bench.file : : free optional ;
 
 .BENCH_FILES = [ os.environ BENCH_FILES ] ;
 

--- a/bench/bench.jam
+++ b/bench/bench.jam
@@ -1,0 +1,5 @@
+import feature ;
+
+feature.feature bench.option : : free optional ;
+feature.feature bench.launcher : : free optional ;
+feature.feature bench.file : : free optional ;


### PR DESCRIPTION
This is so that the module could be easily imported in e.g. project-config.jam and then used for default build, custom build variants, etc.