### PR TITLE
fix value_to for variants

### DIFF
--- a/test/value_to.cpp
+++ b/test/value_to.cpp
@@ -23,6 +23,7 @@
 #include <map>
 #include <unordered_map>
 #include <vector>
+#include <iostream>
 
 #ifndef BOOST_NO_CXX17_HDR_VARIANT
 # include <variant>
@@ -544,6 +545,11 @@ public:
         VT11 v11 = value_to< VT11 >( jv, ctx... );
         BOOST_TEST( v11.index() == 0 );
         BOOST_TEST( get<0>(v11).n == 1024 );
+
+        jv = nullptr;
+        using V_T3_T1 = Variant<value_to_test_ns::T3, value_to_test_ns::T1>;
+        auto v_t3_t1 = value_to<V_T3_T1>( jv, ctx... );
+        BOOST_TEST( v_t3_t1.index() == 1 );
     }
 
     template< class... Context >


### PR DESCRIPTION
After we allowed exceptions to propagate through error_code-based conversions (when the user invoked value_to, rather than try_value_to), we inadvertently broke value_to for variants, because they relied on exceptions being caught by try_value_to. This change disables exception propagation for exactly one level of nesting.