### PR TITLE
Docs: list bench command line options

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -5,6 +5,28 @@ fetch the third party repositories. Then run
 the bench program with no arguments for a
 list of command line options.
 
+```
+Usage: bench [options...] <file>...
+
+Options:  -t:[p][s]            Test parsing, serialization or both
+                                 (default both)
+          -i:[b][d][r][c][n]   Test the specified implementations
+                                 (b: Boost.JSON, pool storage)
+                                 (d: Boost.JSON, default storage)
+                                 (u: Boost.JSON, null parser)
+                                 (s: Boost.JSON, convenient functions)
+                                 (o: Boost.JSON, stream operators)
+                                 (default all)
+          -n:<number>          Number of trials (default 6)
+          -b:<branch>          Branch label for boost implementations
+          -m:(i|p|n)           Number parsing mode
+                                 (i: imprecise)
+                                 (p: precise)
+                                 (n: none)
+                                 (default imprecise)
+          -f                   Include file IO into consideration when testing parsers
+```
+
 When building with b2, it is possible to create several different copies of the
 bench program for different build properties (toolset, build variant, etc.).
 Rather than figuring out where those programs are located from b2 output you


### PR DESCRIPTION
It's not always convenient to "run the bench program with no arguments for a list of command line options" if you want to review the command line options. That requires building and compiling everything.   How about including options in the README page.

One of those options is `-f   Include file IO into consideration when testing parsers`.  Could you double-check and confirm that ordinarily (without the -f option) the benchmarks avoid including file IO in the calculations?  Does that include both ingesting files prior to running the benchmark, as well as writing the results afterwards?  Both of those?  Therefore, when diagnosing the benchmark results the file system read/write time can be ignored?  A (variably) slow disk system would not affect the benchmarks?



