### PR TITLE
Allow to include pretty printers only once

### DIFF
--- a/include/boost/json/debug_printers.hpp
+++ b/include/boost/json/debug_printers.hpp
@@ -7,7 +7,7 @@
 // Official repository: https://github.com/boostorg/json
 //
 
-#ifndef BOOST_JSON_PRINTERS_HPP
+#ifndef BOOST_JSON_DEBUG_PRINTERS_HPP
 
 #include <boost/json/detail/gdb_printers.hpp>
 

--- a/include/boost/json/detail/config.hpp
+++ b/include/boost/json/detail/config.hpp
@@ -233,6 +233,8 @@ constexpr T static_const<T>::value;
 # define BOOST_JSON_DEPRECATED(x)
 #endif
 
+#ifndef BOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS
 #include <boost/json/detail/gdb_printers.hpp>
+#endif
 
 #endif

--- a/include/boost/json/detail/gdb_printers.hpp
+++ b/include/boost/json/detail/gdb_printers.hpp
@@ -12,8 +12,6 @@
 #ifndef BOOST_JSON_DETAIL_GDB_PRINTERS_HPP
 #define BOOST_JSON_DETAIL_GDB_PRINTERS_HPP
 
-#ifndef BOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS
-
 #if defined(__ELF__)
 
 #if defined(__clang__)
@@ -342,7 +340,5 @@ __asm__(
 #endif
 
 #endif // defined(__ELF__)
-
-#endif // BOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS
 
 #endif // BOOST_JSON_DETAIL_GDB_PRINTERS_HPP

--- a/include/boost/json/printers.hpp
+++ b/include/boost/json/printers.hpp
@@ -1,0 +1,14 @@
+//
+// Copyright (c) 2024 Julien Blanc (julien.blanc@tgcm.eu)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/json
+//
+
+#ifndef BOOST_JSON_PRINTERS_HPP
+
+#include <boost/json/detail/gdb_printers.hpp>
+
+#endif


### PR DESCRIPTION
* some linkers will include the section many times in the executable, resulting in increased load time and warning messages inside gdb
* allows including them only once by defining BOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS, and including the printers.hpp file only once.