### PR TITLE
basic implementation of context-based path traction

### DIFF
--- a/include/boost/json/conversion.hpp
+++ b/include/boost/json/conversion.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/json/detail/config.hpp>
 #include <boost/json/fwd.hpp>
+#include <boost/json/string_view.hpp>
 
 #include <type_traits>
 
@@ -436,6 +437,27 @@ struct is_variant_like;
 */
 template<class T>
 struct is_optional_like;
+
+struct context_key_push_tag{};
+struct context_key_pop_tag{};
+struct context_index_push_tag{};
+struct context_index_pop_tag{};
+
+template< class Ctx >
+void
+context_key_push( Ctx const& ctx, string_view sv );
+
+template< class Ctx >
+void
+context_key_pop( Ctx const& ctx );
+
+template< class Ctx >
+void
+context_index_push( Ctx const& ctx, std::size_t n );
+
+template< class Ctx >
+void
+context_index_pop( Ctx const& ctx );
 
 } // namespace json
 } // namespace boost

--- a/include/boost/json/detail/value_to.hpp
+++ b/include/boost/json/detail/value_to.hpp
@@ -232,12 +232,14 @@ value_to_impl(
     auto ins = detail::inserter(res, inserter_implementation<T>());
     for( key_value_pair const& kv: *obj )
     {
+        json::context_key_push( ctx, kv.key() );
         auto elem_res = try_value_to<mapped_type<T>>( kv.value(), ctx );
         if( elem_res.has_error() )
             return {boost::system::in_place_error, elem_res.error()};
         *ins++ = value_type<T>{
             key_type<T>(kv.key()),
             std::move(*elem_res)};
+        json::context_key_pop(ctx);
     }
     return res;
 }
@@ -272,10 +274,12 @@ value_to_impl(
     auto ins = detail::inserter(result, inserter_implementation<T>());
     for( value const& val: *arr )
     {
+        json::context_index_push( ctx, &val - arr->begin() );
         auto elem_res = try_value_to<value_type<T>>( val, ctx );
         if( elem_res.has_error() )
             return {boost::system::in_place_error, elem_res.error()};
         *ins++ = std::move(*elem_res);
+        json::context_index_pop(ctx);
     }
     return result;
 }
@@ -283,13 +287,17 @@ value_to_impl(
 // tuple-like types
 template< class T, class Ctx >
 system::result<T>
-try_make_tuple_elem(value const& jv, Ctx const& ctx, system::error_code& ec)
+try_make_tuple_elem(
+    value const* b, std::size_t n, Ctx const& ctx, system::error_code& ec)
 {
     if( ec.failed() )
         return {boost::system::in_place_error, ec};
 
-    auto result = try_value_to<T>( jv, ctx );
+    json::context_index_push(ctx, n);
+    auto result = try_value_to<T>( b[n], ctx );
     ec = result.error();
+    if( !ec.failed() )
+        json::context_index_pop(ctx);
     return result;
 }
 
@@ -302,7 +310,7 @@ try_make_tuple_like(
     auto items = std::make_tuple(
         try_make_tuple_elem<
             typename std::decay<tuple_element_t<Is, T>>::type >(
-                arr[Is], ctx, ec)
+                arr.data(), Is, ctx, ec)
             ...);
 #if defined(BOOST_GCC)
 # pragma GCC diagnostic push
@@ -377,6 +385,7 @@ struct to_described_member
             return;
         }
 
+        json::context_key_push(ctx, D::name);
 #if defined(__GNUC__) && BOOST_GCC_VERSION >= 80000 && BOOST_GCC_VERSION < 11000
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused"
@@ -387,9 +396,14 @@ struct to_described_member
 # pragma GCC diagnostic pop
 #endif
         if( member_res )
+        {
             (*res).* D::pointer = std::move(*member_res);
+            json::context_key_pop(ctx);
+        }
         else
+        {
             res = {boost::system::in_place_error, member_res.error()};
+        }
     }
 };
 

--- a/include/boost/json/impl/conversion.hpp
+++ b/include/boost/json/impl/conversion.hpp
@@ -563,6 +563,58 @@ struct is_optional_like
         mp11::mp_valid<detail::can_reset, T>>
 { };
 
+inline
+void
+tag_invoke(context_key_push_tag, string_view, ...)
+{
+}
+
+inline
+void
+tag_invoke(context_key_pop_tag, ...)
+{
+}
+
+inline
+void
+tag_invoke(context_index_push_tag, std::size_t, ...)
+{
+}
+
+inline
+void
+tag_invoke(context_index_pop_tag, ...)
+{
+}
+
+template< class Ctx >
+void
+context_key_push(Ctx const& ctx, string_view sv)
+{
+    tag_invoke(context_key_push_tag(), sv, ctx);
+}
+
+template< class Ctx >
+void
+context_key_pop(Ctx const& ctx)
+{
+    tag_invoke(context_key_pop_tag(), ctx);
+}
+
+template< class Ctx >
+void
+context_index_push(Ctx const& ctx, std::size_t n)
+{
+    tag_invoke(context_index_push_tag(), n, ctx);
+}
+
+template< class Ctx >
+void
+context_index_pop(Ctx const& ctx)
+{
+    tag_invoke(context_index_pop_tag(), ctx);
+}
+
 } // namespace json
 } // namespace boost
 


### PR DESCRIPTION
Very rough draft of the idea.

For a context type Ctx the user is supposed to implement these functions:
```
void tag_invoke(context_key_push_tag, string_view,  Ctx const&);
void tag_invoke(context_key_pop_tag, Ctx const&);
void tag_invoke(context_index_push_tag, std::size_t, Ctx const&);
void tag_invoke(context_index_pop_tag, Ctx const&);
```

The library would invoke them when traversing through the converted/parsed/serialized value.

Things to think about:

* The user may actually want to set `error_code` in those callbacks.
* The user may want to clear `error_code` in those functions. But then where would we get the results the calling function was supposed to create?