### PR TITLE
Fix handling of unexpected arrays in nested described struct fields

### DIFF
--- a/include/boost/json/detail/parse_into.hpp
+++ b/include/boost/json/detail/parse_into.hpp
@@ -1052,7 +1052,7 @@ struct ignoring_handler
         --array_depth_;
 
         if( (array_depth_ + object_depth_) == 0 )
-            return parent_->signal_end(ec);
+            return parent_->signal_value(ec);
         return true;
     }
 

--- a/test/parse_into.cpp
+++ b/test/parse_into.cpp
@@ -73,6 +73,18 @@ private:
     BOOST_DESCRIBE_CLASS(Z, (X), (), (), (d))
 };
 
+struct W
+{
+    X x;
+};
+
+BOOST_DESCRIBE_STRUCT(W, (), (x))
+
+bool operator==( W const& w1, W const& w2 )
+{
+    return w1.x == w2.x;
+}
+
 BOOST_DEFINE_ENUM_CLASS(E, x, y, z)
 
 namespace boost {
@@ -401,6 +413,19 @@ public:
         jo["e7"] = false;
         jo["e8"] = nullptr;
         testParseIntoValue<X>(jo);
+
+        object const unexpected_jo{{"x", object{{"unexpectedArray", array{}},
+                                                {"unexpectedObject", object{}},
+                                                {"unexpectedString", "qwerty"},
+                                                {"unexpectedInt", 42},
+                                                {"unexpectedUint", ULONG_MAX},
+                                                {"unexpectedDouble", 2.71},
+                                                {"unexpectedBool", true},
+                                                {"unexpectedNull", nullptr},
+                                                {"a", 1},
+                                                {"b", 3.14f},
+                                                {"c", "hello"}}}};
+        testParseIntoValue<W>(unexpected_jo);
 #endif
     }
 


### PR DESCRIPTION
Fixes a corner case where, when parsing unexpected arrays in nested JSON objects, the `ignoring_handler` would incorrectly signal `signal_end` instead of `signal_value`, causing the parser to skip the rest of the containing object.

```cpp
struct X
{
    int a;
    float b;
    std::string c;
};

BOOST_DESCRIBE_STRUCT(X, (), (a, b, c))

struct W
{
    X x;
};

BOOST_DESCRIBE_STRUCT(W, (), (x))

// ...

const auto json = R"(
{
    "x": {
        "unexpected": [],
        "a": 1,
        "b": 3.14,
        "c": "hello"
    }
})";

W w{};
std::error_code ec;
parse_into(w, json, ec);

BOOST_TEST( !ec );               // Ok.
BOOST_TEST( w.x.a == 1 );        // Error: w.x.a is 0
BOOST_TEST( w.x.b == 3.14f );    // Error: w.x.b is 0.0
BOOST_TEST( w.x.c == "hello" );  // Error: w.x.c is ""
```