### PR TITLE
clamp count in string_impl::replace_unchecked

### DIFF
--- a/include/boost/json/detail/impl/string_impl.ipp
+++ b/include/boost/json/detail/impl/string_impl.ipp
@@ -395,6 +395,7 @@ replace_unchecked(
         detail::throw_system_error( error::out_of_range, &loc );
     }
     const auto curr_data = data();
+    n1 = (std::min)(n1, curr_size - pos);
     const auto delta = (std::max)(n1, n2) -
         (std::min)(n1, n2);
     // if the size doesn't change, we don't need to

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -2419,6 +2419,34 @@ public:
                            s1.replace(0, 1, 1, 'a'));
             });
 
+            // count exceeds size() - pos: clamped to size() - pos (sbo)
+            fail_loop([&](storage_ptr const& sp)
+            {
+                std::string s1(t.v1.data(), t.v1.size());
+                string s2(t.v1, sp);
+                BOOST_TEST(s2.replace(1, s2.size() + 100, 3, 'a') ==
+                           s1.replace(1, s1.size() + 100, 3, 'a'));
+            });
+
+            // count exceeds size() - pos: erase from pos to end
+            fail_loop([&](storage_ptr const& sp)
+            {
+                std::string s1(t.v2.data(), t.v2.size());
+                string s2(t.v2, sp);
+                BOOST_TEST(s2.replace(0, s2.size() + 100, 0, 'a') ==
+                           s1.replace(0, s1.size() + 100, 0, 'a'));
+            });
+
+            // count exceeds size() - pos, with growth and realloc
+            fail_loop([&](storage_ptr const& sp)
+            {
+                std::string s1(t.v2.data(), t.v2.size());
+                string s2(t.v2, sp);
+                const auto grow = (std::max)(s1.capacity(), s2.capacity()) + 1;
+                BOOST_TEST(s2.replace(2, s2.size() + 100, grow, 'a') ==
+                           s1.replace(2, s1.size() + 100, grow, 'a'));
+            });
+
             // pos out of range
             fail_loop([&](storage_ptr const& sp)
             {


### PR DESCRIPTION
Repro: `boost::json::string("hello").replace(0, 100, 0, 'x')` — the count exceeds `size() - pos`.
Cause: `string_impl::replace_unchecked` doesn't clamp `n1` to `size() - pos`, so `curr_size - pos - n1 + 1` underflows and the `memmove` runs a near-`SIZE_MAX` length out of bounds (ASAN: `negative-size-param` at string_impl.ipp:409). Overload (4) `string::replace(pos, count, count2, ch)` forwards `count` unchanged, though it is documented to replace `std::min(count, size() - pos)` characters. The `string_view` overload already clamps via `string_impl::replace`.
Fix: clamp `n1` to `size() - pos`, matching `string_impl::replace`.