### PR TITLE
copy fill value before reallocation in array::insert/resize

### DIFF
--- a/include/boost/json/impl/array.ipp
+++ b/include/boost/json/impl/array.ipp
@@ -494,11 +494,15 @@ insert(
     value const& v) ->
         iterator
 {
+    // v may refer to an element of this array, whose
+    // storage revert_insert can relocate and free, so
+    // copy it before inserting
+    value const tmp(v, sp_);
     revert_insert r(
         pos, count, *this);
     while(count--)
     {
-        ::new(r.p) value(v, sp_);
+        ::new(r.p) value(tmp, sp_);
         ++r.p;
     }
     return r.commit();
@@ -619,11 +623,15 @@ resize(
         return;
     }
     count -= size();
+    // v may refer to an element of this array, whose
+    // storage revert_insert can relocate and free, so
+    // copy it before inserting
+    value const tmp(v, sp_);
     revert_insert r(
         end(), count, *this);
     while(count--)
     {
-        ::new(r.p) value(v, sp_);
+        ::new(r.p) value(tmp, sp_);
         ++r.p;
     }
     r.commit();

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -941,6 +941,24 @@ public:
                 BOOST_TEST(a[3].as_array().size() == 3);
                 BOOST_TEST(a[4].is_string());
             });
+
+            // value aliases an element and insertion reallocates
+            fail_loop([&](storage_ptr const& sp)
+            {
+                array a(sp);
+                a.reserve(4);
+                a.emplace_back(1);
+                a.emplace_back(2);
+                a.emplace_back(3);
+                a.emplace_back(4);
+                BOOST_TEST(a.capacity() == a.size());
+                a.insert(a.begin(), 6, a[0]);
+                BOOST_TEST(a.size() == 10);
+                for(std::size_t i = 0; i < 7; ++i)
+                    BOOST_TEST(a[i].as_int64() == 1);
+                BOOST_TEST(a[9].as_int64() == 4);
+                check_storage(a, sp);
+            });
         }
 
         // insert(const_iterator, InputIt, InputIt)
@@ -1167,6 +1185,24 @@ public:
                 array a(3, v, sp);
                 a.resize(5, v);
                 BOOST_TEST(a.size() == 5);
+                check_storage(a, sp);
+            });
+
+            // value aliases an element and the resize reallocates
+            fail_loop([&](storage_ptr const& sp)
+            {
+                array a(sp);
+                a.reserve(4);
+                a.emplace_back(10);
+                a.emplace_back(20);
+                a.emplace_back(30);
+                a.emplace_back(40);
+                BOOST_TEST(a.capacity() == a.size());
+                a.resize(12, a[1]);
+                BOOST_TEST(a.size() == 12);
+                BOOST_TEST(a[1].as_int64() == 20);
+                for(std::size_t i = 4; i < 12; ++i)
+                    BOOST_TEST(a[i].as_int64() == 20);
                 check_storage(a, sp);
             });
         }


### PR DESCRIPTION
Repro: on a full array, `a.insert(a.begin(), n, a[0])` or `a.resize(n, a[1])` reads freed memory (ASAN heap-use-after-free in the value copy constructor).
Cause: revert_insert relocates the elements into a newly allocated table and frees the old one before the fill loop runs, so a value that aliases an existing element is left dangling.
Fix: copy the value into a local before constructing revert_insert, the same snapshot object::emplace_impl and array::emplace already take. std::vector defines these self-referential fills, so the copy overloads should honour it too.