### PR TITLE
fix self-append use-after-free in string::append

### DIFF
--- a/include/boost/json/detail/string_impl.hpp
+++ b/include/boost/json/detail/string_impl.hpp
@@ -27,6 +27,12 @@ class string;
 
 namespace detail {
 
+bool
+ptr_in_range(
+    const char* first,
+    const char* last,
+    const char* ptr) noexcept;
+
 class string_impl
 {
     struct table

--- a/include/boost/json/impl/string.ipp
+++ b/include/boost/json/impl/string.ipp
@@ -284,9 +284,22 @@ string&
 string::
 append(string_view sv)
 {
-    std::char_traits<char>::copy(
-        impl_.append(sv.size(), sp_),
-        sv.data(), sv.size());
+    auto const p = impl_.data();
+    if(detail::ptr_in_range(p, p + impl_.size(), sv.data()))
+    {
+        // sv aliases our own storage; appending may reallocate and free the
+        // buffer sv points into, so copy from the relocated offset afterwards
+        auto const offset = sv.data() - p;
+        auto const dest = impl_.append(sv.size(), sp_);
+        std::char_traits<char>::copy(
+            dest, impl_.data() + offset, sv.size());
+    }
+    else
+    {
+        std::char_traits<char>::copy(
+            impl_.append(sv.size(), sp_),
+            sv.data(), sv.size());
+    }
     return *this;
 }
 

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -2033,6 +2033,34 @@ public:
                 BOOST_TEST(s == t.s2 + t.s1.substr(2, 3));
             });
         }
+
+        // self-append with aliased source forcing reallocation
+        {
+            fail_loop([&](storage_ptr const& sp)
+            {
+                string s(sp);
+                s.append(t.v2);
+                // consume any spare capacity so the next append reallocates
+                while(s.size() < s.capacity())
+                    s.push_back('*');
+                std::string cs(s.data(), s.size());
+                s.append(s);
+                cs.append(cs);
+                BOOST_TEST(s == cs);
+            });
+
+            fail_loop([&](storage_ptr const& sp)
+            {
+                string s(sp);
+                s.append(t.v2);
+                while(s.size() < s.capacity())
+                    s.push_back('*');
+                std::string cs(s.data(), s.size());
+                s.append(s.subview(3));
+                cs.append(cs.substr(3));
+                BOOST_TEST(s == cs);
+            });
+        }
     }
 
     void


### PR DESCRIPTION
Repro: on a heap string with no spare capacity, `s += s` (equivalently `s.append(s)` or `s.append(s.subview(k))`).
Cause: append(string_view) copies from sv after string_impl::append has reallocated and freed the buffer sv points into, so the copy reads freed memory (ASAN heap-use-after-free). insert and replace already guard self-aliasing via detail::ptr_in_range; append was the gap.
Fix: detect the alias before appending and copy from the relocated offset in the resulting buffer.

Regression tests in test/string.cpp cover whole and partial self-append forcing reallocation; they report a use-after-free before the change and pass after.