### PR TITLE
buffer source before reallocation in string::append(InputIt, InputIt)

### DIFF
--- a/include/boost/json/impl/string.hpp
+++ b/include/boost/json/impl/string.hpp
@@ -195,24 +195,42 @@ append(
     InputIt last,
     std::random_access_iterator_tag)
 {
-
     auto const n = static_cast<
         size_type>(last - first);
-    if(n > impl_.capacity() - impl_.size())
+    auto const size = impl_.size();
+    detail::string_impl tmp;
+    char* p = impl_.data();
+    if(n > impl_.capacity() - size)
     {
-        // appending forces a reallocation that frees our storage; if
-        // [first, last) aliases it the copy below would read freed memory,
-        // so buffer the characters first
-        append(first, last, std::input_iterator_tag{});
-        return;
+        // [first, last) may alias the current
+        // storage, so copy the new characters
+        // into the new storage before freeing it
+        tmp = detail::string_impl(
+            detail::string_impl::growth(
+                size + n, impl_.capacity()),
+            sp_);
+        p = tmp.data();
     }
-    char* out = impl_.append(n, sp_);
+
+    char* out = p + size;
 #if defined(_MSC_VER) && _MSC_VER <= 1900
     while( first != last )
         *out++ = *first++;
 #else
     std::copy(first, last, out);
 #endif
+
+    if(p != impl_.data())
+    {
+        std::memcpy(p, impl_.data(), size);
+        tmp.term(size + n);
+        impl_.destroy(sp_);
+        impl_ = tmp;
+    }
+    else
+    {
+        impl_.term(size + n);
+    }
 }
 
 template<class InputIt>

--- a/include/boost/json/impl/string.hpp
+++ b/include/boost/json/impl/string.hpp
@@ -198,6 +198,14 @@ append(
 
     auto const n = static_cast<
         size_type>(last - first);
+    if(n > impl_.capacity() - impl_.size())
+    {
+        // appending forces a reallocation that frees our storage; if
+        // [first, last) aliases it the copy below would read freed memory,
+        // so buffer the characters first
+        append(first, last, std::input_iterator_tag{});
+        return;
+    }
     char* out = impl_.append(n, sp_);
 #if defined(_MSC_VER) && _MSC_VER <= 1900
     while( first != last )

--- a/include/boost/json/impl/string.hpp
+++ b/include/boost/json/impl/string.hpp
@@ -223,14 +223,10 @@ append(
     if(p != impl_.data())
     {
         std::memcpy(p, impl_.data(), size);
-        tmp.term(size + n);
         impl_.destroy(sp_);
         impl_ = tmp;
     }
-    else
-    {
-        impl_.term(size + n);
-    }
+    impl_.term(size + n);
 }
 
 template<class InputIt>

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -2071,17 +2071,6 @@ public:
                 while(s.size() < s.capacity())
                     s.push_back('*');
                 std::string const cs(s.data(), s.size());
-                s.append(s.begin(), s.end());
-                BOOST_TEST(s == cs + cs);
-            });
-
-            fail_loop([&](storage_ptr const& sp)
-            {
-                string s(sp);
-                s.append(t.v2);
-                while(s.size() < s.capacity())
-                    s.push_back('*');
-                std::string const cs(s.data(), s.size());
                 auto const sv = s.subview(3);
                 s.append(sv.begin(), sv.end());
                 BOOST_TEST(s == cs + cs.substr(3));

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -2061,6 +2061,32 @@ public:
                 BOOST_TEST(s == cs);
             });
         }
+
+        // self-append via the iterator overload forcing reallocation
+        {
+            fail_loop([&](storage_ptr const& sp)
+            {
+                string s(sp);
+                s.append(t.v2);
+                while(s.size() < s.capacity())
+                    s.push_back('*');
+                std::string const cs(s.data(), s.size());
+                s.append(s.begin(), s.end());
+                BOOST_TEST(s == cs + cs);
+            });
+
+            fail_loop([&](storage_ptr const& sp)
+            {
+                string s(sp);
+                s.append(t.v2);
+                while(s.size() < s.capacity())
+                    s.push_back('*');
+                std::string const cs(s.data(), s.size());
+                auto const sv = s.subview(3);
+                s.append(sv.begin(), sv.end());
+                BOOST_TEST(s == cs + cs.substr(3));
+            });
+        }
     }
 
     void


### PR DESCRIPTION
Repro: on a heap string with no spare capacity, self-append through the iterator overload, e.g. `s.append(s.begin(), s.end())` or `s.append(s.subview(k).begin(), s.subview(k).end())`.
Cause: append(InputIt, InputIt) sends random-access iterators to a path that grows the buffer with string_impl::append and then std::copy(first, last, out). The append reallocates and frees the old buffer that [first, last) points into, so the copy reads freed memory (ASAN heap-use-after-free at string.hpp:206). The string_view and input-iterator overloads already avoid this; the random-access one copied straight from the aliased source.
Fix: when the append would reallocate, buffer the characters through the input-iterator path first, and keep the in-place copy when there is spare capacity. std::string defines this overload as append(basic_string(first, last)), so self-referential ranges are well defined.

Regression tests in test/string.cpp self-append through the iterator overload with capacity consumed so the append reallocates; they report a use-after-free before the change and pass after.