### PR TITLE
fix overflow check in parse_number_token

### DIFF
--- a/include/boost/json/impl/pointer.ipp
+++ b/include/boost/json/impl/pointer.ipp
@@ -200,15 +200,19 @@ parse_number_token(
             return {};
         }
 
-        // guard against std::size_t overflow in result * 10 + d
-        if( result > (std::size_t(-1) - d) / 10 )
+        if( result > std::size_t(-1) / 10 )
         {
             BOOST_JSON_FAIL(ec, error::token_overflow);
             return {};
         }
+        result *= 10;
 
-        result = result * 10 + d;
-
+        if( result > std::size_t(-1) - d )
+        {
+            BOOST_JSON_FAIL(ec, error::token_overflow);
+            return {};
+        }
+        result += d;
     }
     return result;
 }

--- a/include/boost/json/impl/pointer.ipp
+++ b/include/boost/json/impl/pointer.ipp
@@ -200,14 +200,14 @@ parse_number_token(
             return {};
         }
 
-        std::size_t new_result = result * 10 + d;
-        if( new_result < result )
+        // guard against std::size_t overflow in result * 10 + d
+        if( result > (std::size_t(-1) - d) / 10 )
         {
             BOOST_JSON_FAIL(ec, error::token_overflow);
             return {};
         }
 
-        result = new_result;
+        result = result * 10 + d;
 
     }
     return result;

--- a/test/pointer.cpp
+++ b/test/pointer.cpp
@@ -231,6 +231,14 @@ public:
         jv.find_pointer(s, ec);
         BOOST_TEST(ec == error::token_overflow);
         BOOST_TEST(hasLocation(ec));
+
+        // a token an order of magnitude past max() still overflows size_t
+        string s2 = "/foo/";
+        s2 += std::to_string((std::numeric_limits<std::size_t>::max)());
+        s2 += '9';
+        jv.find_pointer(s2, ec);
+        BOOST_TEST(ec == error::token_overflow);
+        BOOST_TEST(hasLocation(ec));
     }
 
     void


### PR DESCRIPTION
    value{{"foo", {1, 2, 3}}}.find_pointer(
        "/foo/" + std::to_string(SIZE_MAX) + "9", ec);
    // ec == error::not_found, expected error::token_overflow

parse_number_token flags `std::size_t` overflow with `new_result < result`, the
addition-overflow idiom, but the accumulation is `result * 10 + d`. Once
`result * 10` wraps, the wrapped value plus `d` can land at or above `result`,
so a pointer token an order of magnitude past `max()` slips through and resolves
to a bogus (out-of-range) index, reporting `error::not_found` rather than
`error::token_overflow`. Replaced with the pre-check
`result > (std::size_t(-1) - d) / 10`.

The regression test appends a digit to `max()` and expects `token_overflow`; it
fails before the change and passes after. The existing overflow test only covers
`max() + 1`, which happens to wrap below `result` and so was already caught.