### PR TITLE
use array storage in insert(pos, first, last)

### DIFF
--- a/include/boost/json/impl/array.hpp
+++ b/include/boost/json/impl/array.hpp
@@ -565,7 +565,7 @@ insert(
     revert_insert r(pos, n, *this);
     while(n--)
     {
-        ::new(r.p) value(*first++);
+        ::new(r.p) value(*first++, sp_);
         ++r.p;
     }
     return r.commit();

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -971,7 +971,7 @@ public:
                 array a({str_}, sp);
                 a.insert(a.begin(),
                     init.begin(), init.end());
-                check(a);
+                check(a, sp);
             });
 
             // random iterator (multiple growth)
@@ -1008,7 +1008,7 @@ public:
                 a.insert(a.begin(),
                     make_input_iterator(init.begin()),
                     make_input_iterator(init.end()));
-                check(a);
+                check(a, sp);
             });
 
             // input iterator (multiple growth)


### PR DESCRIPTION
Repro: back an array with a non-default resource and insert a forward-iterator range, e.g. `array a(&mr); a.insert(a.end(), v.begin(), v.end());` with `mr` a `monotonic_resource`. The inserted elements report a `storage()` different from `a.storage()`.
Cause: the forward-iterator `insert` overload constructs each element as `value(*first++)`, copying with the source value's storage rather than the array's `sp_`. Both range constructors, the input-iterator `insert` overload, and the count-fill overload already pass `sp_`; this path was the one that did not.
Fix: pass `sp_` so inserted elements adopt the array's storage.

Old behaviour also leaks: with a trivially-deallocatable resource the array destructor fast path skips element destructors, so any heap allocation an inserted element owns is never freed.

The regression test extends the existing random-iterator insert case to check element storage; it fails before the change and passes after.