### PR TITLE
buffer initializer_list before reallocation in array::insert

### DIFF
--- a/include/boost/json/impl/array.ipp
+++ b/include/boost/json/impl/array.ipp
@@ -516,10 +516,21 @@ insert(
         value_ref> init) ->
     iterator
 {
+    BOOST_ASSERT(
+        pos >= begin() && pos <= end());
+    if(init.size() == 0)
+        return data() + (pos - data());
+    // the value_refs in init may point into this
+    // array, whose storage revert_insert can
+    // relocate and free, so buffer them first
+    array temp(init, sp_);
     revert_insert r(
-        pos, init.size(), *this);
-    value_ref::write_array(
-        r.p, init, sp_);
+        pos, temp.size(), *this);
+    relocate(
+        r.p,
+        temp.data(),
+        temp.size());
+    temp.t_->size = 0;
     return r.commit();
 }
 

--- a/include/boost/json/impl/array.ipp
+++ b/include/boost/json/impl/array.ipp
@@ -516,10 +516,6 @@ insert(
         value_ref> init) ->
     iterator
 {
-    BOOST_ASSERT(
-        pos >= begin() && pos <= end());
-    if(init.size() == 0)
-        return data() + (pos - data());
     // the value_refs in init may point into this
     // array, whose storage revert_insert can
     // relocate and free, so buffer them first

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -1035,18 +1035,35 @@ public:
         }
 
         // insert(const_iterator, init_list)
-        fail_loop([&](storage_ptr const& sp)
         {
-            array a({0, 3, 4}, sp);
-            auto it = a.insert(
-                a.begin() + 1, {1, str_});
-            BOOST_TEST(it == a.begin() + 1);
-            BOOST_TEST(a[0].as_int64() == 0);
-            BOOST_TEST(a[1].as_int64() == 1);
-            BOOST_TEST(a[2].as_string() == str_);
-            BOOST_TEST(a[3].as_int64() == 3);
-            BOOST_TEST(a[4].as_int64() == 4);
-        });
+            fail_loop([&](storage_ptr const& sp)
+            {
+                array a({0, 3, 4}, sp);
+                auto it = a.insert(
+                    a.begin() + 1, {1, str_});
+                BOOST_TEST(it == a.begin() + 1);
+                BOOST_TEST(a[0].as_int64() == 0);
+                BOOST_TEST(a[1].as_int64() == 1);
+                BOOST_TEST(a[2].as_string() == str_);
+                BOOST_TEST(a[3].as_int64() == 3);
+                BOOST_TEST(a[4].as_int64() == 4);
+            });
+
+            // elements of init alias *this and
+            // insertion reallocates
+            fail_loop([&](storage_ptr const& sp)
+            {
+                array a({1, str_}, sp);
+                BOOST_TEST(a.capacity() == a.size());
+                a.insert(a.begin(), {a[0], a[1]});
+                BOOST_TEST(a.size() == 4);
+                BOOST_TEST(a[0].as_int64() == 1);
+                BOOST_TEST(a[1].as_string() == str_);
+                BOOST_TEST(a[2].as_int64() == 1);
+                BOOST_TEST(a[3].as_string() == str_);
+                check_storage(a, sp);
+            });
+        }
 
         // emplace(const_iterator, arg)
         fail_loop([&](storage_ptr const& sp)

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -1035,35 +1035,30 @@ public:
         }
 
         // insert(const_iterator, init_list)
+        fail_loop([&](storage_ptr const& sp)
         {
-            fail_loop([&](storage_ptr const& sp)
-            {
-                array a({0, 3, 4}, sp);
-                auto it = a.insert(
-                    a.begin() + 1, {1, str_});
-                BOOST_TEST(it == a.begin() + 1);
-                BOOST_TEST(a[0].as_int64() == 0);
-                BOOST_TEST(a[1].as_int64() == 1);
-                BOOST_TEST(a[2].as_string() == str_);
-                BOOST_TEST(a[3].as_int64() == 3);
-                BOOST_TEST(a[4].as_int64() == 4);
-            });
+            array a({0, 3, 4}, sp);
+            auto it = a.insert(
+                a.begin() + 1, {1, str_});
+            BOOST_TEST(it == a.begin() + 1);
+            BOOST_TEST(a[0].as_int64() == 0);
+            BOOST_TEST(a[1].as_int64() == 1);
+            BOOST_TEST(a[2].as_string() == str_);
+            BOOST_TEST(a[3].as_int64() == 3);
+            BOOST_TEST(a[4].as_int64() == 4);
 
             // elements of init alias *this and
             // insertion reallocates
-            fail_loop([&](storage_ptr const& sp)
-            {
-                array a({1, str_}, sp);
-                BOOST_TEST(a.capacity() == a.size());
-                a.insert(a.begin(), {a[0], a[1]});
-                BOOST_TEST(a.size() == 4);
-                BOOST_TEST(a[0].as_int64() == 1);
-                BOOST_TEST(a[1].as_string() == str_);
-                BOOST_TEST(a[2].as_int64() == 1);
-                BOOST_TEST(a[3].as_string() == str_);
-                check_storage(a, sp);
-            });
-        }
+            array b({1, str_}, sp);
+            BOOST_TEST(b.capacity() == b.size());
+            b.insert(b.begin(), {b[0], b[1]});
+            BOOST_TEST(b.size() == 4);
+            BOOST_TEST(b[0].as_int64() == 1);
+            BOOST_TEST(b[1].as_string() == str_);
+            BOOST_TEST(b[2].as_int64() == 1);
+            BOOST_TEST(b[3].as_string() == str_);
+            check_storage(b, sp);
+        });
 
         // emplace(const_iterator, arg)
         fail_loop([&](storage_ptr const& sp)


### PR DESCRIPTION
Repro: `a.insert(a.begin(), {a[0], a[1]})` on an array with `size() == capacity()` reports an ASAN heap-use-after-free; the `initializer_list<value_ref>` overload builds `revert_insert` first, which on the growth path frees the old table before `write_array` dereferences the `value_ref`s that point into it.
Fix: materialise the init-list into a temporary array before constructing `revert_insert`, then relocate, matching the input-iterator insert path. The regression test inserts a self-referential init-list into a full array; it reports a heap-use-after-free under ASAN before the fix and passes after.