### PR TITLE
fix overlapping memcpy in string::assign

### DIFF
--- a/include/boost/json/impl/string.ipp
+++ b/include/boost/json/impl/string.ipp
@@ -176,9 +176,18 @@ assign(
     char const* s,
     size_type count)
 {
-    std::char_traits<char>::copy(
-        impl_.assign(count, sp_),
-        s, count);
+    auto const p = impl_.data();
+    if(detail::ptr_in_range(p, p + impl_.size(), s))
+    {
+        std::char_traits<char>::move(p, s, count);
+        impl_.term(count);
+    }
+    else
+    {
+        std::char_traits<char>::copy(
+            impl_.assign(count, sp_),
+            s, count);
+    }
     return *this;
 }
 

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -840,6 +840,36 @@ public:
             });
         };
 
+        // assign(char const*, size_type) self-referencing
+        {
+            // non-SBO: assign from a substring of itself
+            {
+                string s("abcdefghijklmnopqrstuvwxyz0123456789");
+                string_view sub(s.data() + 3, s.size() - 3);
+                std::string expected(sub.data(), sub.size());
+                s.assign(sub);
+                BOOST_TEST(s == expected);
+            }
+
+            // non-SBO: assign from beginning (prefix)
+            {
+                string s("abcdefghijklmnopqrstuvwxyz0123456789");
+                string_view sub(s.data(), 10);
+                std::string expected(sub.data(), sub.size());
+                s.assign(sub);
+                BOOST_TEST(s == expected);
+            }
+
+            // non-SBO: self-assign via string_view
+            {
+                string s("abcdefghijklmnopqrstuvwxyz0123456789");
+                string_view sub(s.data(), s.size());
+                std::string expected(sub.data(), sub.size());
+                s.assign(sub);
+                BOOST_TEST(s == expected);
+            }
+        }
+
         // assign(char const* s)
         {
             fail_loop([&](storage_ptr const& sp)


### PR DESCRIPTION
## Summary

`string::assign(char const* s, size_type count)` uses
`char_traits::copy` (memcpy) unconditionally.  When `s` points into
the string's own buffer — e.g. via `s.assign(string_view(s).substr(3))` —
the source and destination regions overlap, which is undefined behaviour
per [mem.res]/[char.traits.require].

Under AddressSanitizer this fires `memcpy-param-overlap`; without
instrumentation it silently corrupts the result on some compilers/optimisation
levels.

## Fix

Detect aliasing with `detail::ptr_in_range`.  When the source is internal,
use `char_traits::move` (memmove) directly followed by `impl_.term(count)`.
The non-aliasing path remains unchanged.

The aliasing case guarantees `count <= size() <= capacity()`, so no
reallocation is needed and bypassing `impl_.assign` is safe.

## Reproducer

```cpp
boost::json::string s("abcdefghijklmnopqrstuvwxyz0123456789");
s.assign(boost::json::string_view(s).substr(3));
// ASAN: memcpy-param-overlap
// Without ASAN: silent data corruption (null terminator overwrites source)
```

## Labels

- component: `boost/json/string`
- type: `memcpy-param-overlap` / undefined behaviour
- severity: medium — data corruption on common self-referencing patterns
- affected: `string::assign(char const*, size_type)` and all callers
  (`operator=(string_view)`, `assign(string_view)`, construction from
  self-referencing `string_view`)