### PR TITLE
fix string corruption in string_impl::shrink_to_fit

### DIFF
--- a/include/boost/json/detail/impl/string_impl.ipp
+++ b/include/boost/json/detail/impl/string_impl.ipp
@@ -435,9 +435,10 @@ shrink_to_fit(
     auto const t = p_.t;
     if(t->size <= sbo_chars_)
     {
+        char const* const p = data();
         s_.k = short_string_;
         std::memcpy(
-            s_.buf, data(), t->size);
+            s_.buf, p, t->size);
         s_.buf[sbo_chars_] =
             static_cast<char>(
                 sbo_chars_ - t->size);
@@ -458,7 +459,7 @@ shrink_to_fit(
         std::memcpy(
             tmp.data(),
             data(),
-            size());
+            size() + 1);
         destroy(sp);
         *this = tmp;
 #ifndef BOOST_NO_EXCEPTIONS

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -1368,6 +1368,38 @@ public:
             s.shrink_to_fit();
             BOOST_TEST(s.capacity() < cap);
         });
+
+        // shrink_to_fit() preserves the contents across reallocation
+        {
+            std::size_t const sbo = string{}.capacity();
+
+            // heap -> SBO: shrink a dynamic string down to fit in the SBO
+            {
+                std::string big(sbo * 3, '\0');
+                std::iota(big.begin(), big.end(), 'a');
+                string s(big.data(), big.size());
+                BOOST_TEST(s.capacity() > sbo);
+                std::size_t const n = sbo / 2;
+                s.resize(n);
+                s.shrink_to_fit();
+                BOOST_TEST(s.size() == n);
+                BOOST_TEST(s == string_view(big.data(), n));
+                BOOST_TEST(s.c_str()[s.size()] == '\0');
+            }
+
+            // heap -> smaller heap: still larger than the SBO after shrinking
+            {
+                std::string big(sbo * 4, '\0');
+                std::iota(big.begin(), big.end(), 'A');
+                string s(big.data(), big.size());
+                std::size_t const n = sbo * 2;
+                s.resize(n);
+                s.shrink_to_fit();
+                BOOST_TEST(s.size() == n);
+                BOOST_TEST(s == string_view(big.data(), n));
+                BOOST_TEST(s.c_str()[s.size()] == '\0');
+            }
+        }
     }
 
     void


### PR DESCRIPTION
Repro: build a heap-allocated `string` (size past the SBO), shrink its size to at most the SBO capacity, then call `shrink_to_fit()`; the contents come back as unrelated bytes. Second case: shrink a heap string that stays above the SBO capacity, then read `c_str()`, and `strlen` exceeds `size()`.

Cause: in the heap-to-SBO branch `s_.k` is set to `short_string_` before `data()` is read, so once the kind has flipped `data()` returns the inline SBO buffer and the memcpy copies that buffer onto itself rather than the heap characters, leaving stale union bytes (the old table pointer among them). In the heap-to-smaller-heap branch only `size()` bytes are copied, so the terminator is dropped and `c_str()` reads into uninitialised storage.

Fix: read the source pointer before switching the kind, and copy `size() + 1` bytes on the reallocating branch so the terminator is carried across.
