### PR TITLE
reuse existing capacity in sbo_buffer::grow

### DIFF
--- a/include/boost/json/detail/sbo_buffer.hpp
+++ b/include/boost/json/detail/sbo_buffer.hpp
@@ -151,6 +151,9 @@ public:
         }
 
         std::size_t const old_capacity = this->capacity();
+        if( size <= old_capacity - size_ )
+            return;
+
         std::size_t new_capacity = size_ + size;
 
         // growth factor 2

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -37,6 +37,7 @@ local SOURCES =
     pilfer.cpp
     pointer.cpp
     result_for.cpp
+    sbo_buffer.cpp
     serialize.cpp
     serializer.cpp
     snippets.cpp

--- a/test/sbo_buffer.cpp
+++ b/test/sbo_buffer.cpp
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2026 Ramya Eliger (ramya@digiscrypt.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/json
+//
+
+#include <boost/json/detail/sbo_buffer.hpp>
+#include <boost/json/string_view.hpp>
+
+#include <string>
+
+#include "test_suite.hpp"
+
+namespace boost {
+namespace json {
+
+class sbo_buffer_test
+{
+public:
+    void
+    testInlineStorage()
+    {
+        detail::sbo_buffer<32> buf;
+        std::size_t const cap = buf.capacity();
+        BOOST_TEST(cap >= 32);
+
+        char const* p = buf.append("1.2", 3);
+        BOOST_TEST(buf.size() == 3);
+        BOOST_TEST(string_view(p, buf.size()) == "1.2");
+        BOOST_TEST(buf.capacity() == cap);
+
+        p = buf.append("5e10", 4);
+        BOOST_TEST(buf.size() == 7);
+        BOOST_TEST(string_view(p, buf.size()) == "1.25e10");
+        BOOST_TEST(buf.capacity() == cap);
+    }
+
+    void
+    testReuse()
+    {
+        detail::sbo_buffer<32> buf;
+        std::size_t const cap = buf.capacity();
+        for(int i = 0; i < 40; ++i)
+        {
+            buf.clear();
+            char const* p = buf.append("1.25", 4);
+            BOOST_TEST(buf.size() == 4);
+            BOOST_TEST(string_view(p, buf.size()) == "1.25");
+        }
+        BOOST_TEST(buf.capacity() == cap);
+    }
+
+    void
+    testGrowth()
+    {
+        detail::sbo_buffer<32> buf;
+        std::string const s(1000, 'x');
+
+        char const* p = buf.append(s.data(), s.size());
+        BOOST_TEST(buf.size() == s.size());
+        BOOST_TEST(buf.capacity() >= s.size());
+        BOOST_TEST(string_view(p, buf.size()) == s);
+
+        std::size_t const cap = buf.capacity();
+        buf.clear();
+        p = buf.append("1.25", 4);
+        BOOST_TEST(buf.size() == 4);
+        BOOST_TEST(string_view(p, buf.size()) == "1.25");
+        BOOST_TEST(buf.capacity() == cap);
+
+        buf.reset();
+        BOOST_TEST(buf.size() == 0);
+        BOOST_TEST(buf.capacity() == 32);
+    }
+
+    void
+    run()
+    {
+        testInlineStorage();
+        testReuse();
+        testGrowth();
+    }
+};
+
+TEST_SUITE(sbo_buffer_test, "boost.json.sbo_buffer");
+
+} // namespace json
+} // namespace boost


### PR DESCRIPTION
Repro: a 200-element `[1.25,...]` array (1001 bytes) fed to `stream_parser` a byte at a time with `number_precision::precise`, so every number straddles a `write_some` boundary, makes 813 global `operator new` calls totalling 56.1 GB with a largest single block of 1.14 GB; a 32 KB body in 4 KiB chunks peaks at a 2.2 MB block, and that peak keeps doubling as the body grows.
Cause: `grow` never checks whether the buffer already has room, so every `append` reallocates and each one floors the new capacity at `old_capacity * 2`, while `clear` keeps the block, so the doubling carries across numbers and across `reset`, and the inline buffer goes unused past the first append.
Fix: return early when the requested size fits the current capacity, matching what `string_impl::append` already does; the two runs above then total 19.8 kB and 240 kB, with largest blocks of 6 kB and 48 kB.
