### PR TITLE
fix deallocate argument in monotonic_resource

### DIFF
--- a/include/boost/json/impl/monotonic_resource.ipp
+++ b/include/boost/json/impl/monotonic_resource.ipp
@@ -103,7 +103,7 @@ release() noexcept
     while(p != &buffer_)
     {
         auto next = p->next;
-        upstream_->deallocate(p, p->size);
+        upstream_->deallocate(p, sizeof(block) + p->size);
         p = next;
     }
     buffer_.p = reinterpret_cast<

--- a/test/monotonic_resource.cpp
+++ b/test/monotonic_resource.cpp
@@ -18,6 +18,7 @@
 #include <boost/core/max_align.hpp>
 #include <iostream>
 
+#include "checking_resource.hpp"
 #include "test_suite.hpp"
 
 namespace boost {
@@ -306,11 +307,23 @@ R"xx({
     }
 
     void
+    testAllocation()
+    {
+        // every block obtained from the upstream resource has to be
+        // returned to it with the size it was allocated with
+        BOOST_TEST_CHECKPOINT();
+        checking_resource res;
+        monotonic_resource mr(1, &res);
+        (void)mr.allocate(1, alignof(core::max_align_t));
+    }
+
+    void
     run()
     {
         testMembers();
         testStorage();
         testGeneral();
+        testAllocation();
     }
 };
 


### PR DESCRIPTION
Repro: parse anything through a `monotonic_resource` whose upstream is `test/checking_resource.hpp`. Every block fails `size == it->second.first`.

Cause: `do_allocate` asks the upstream for `sizeof(block) + next_size_` but records only `next_size_` in `block::size`, so `release()` returns each block 32 bytes short on LP64. The default resource ignores the size argument, so this only bites upstreams that bucket by size.

Fix: add the header size back before deallocating. The key-string alignment fix that was originally part of this PR moved to #1181.