### PR TITLE
[doc] Drop the stray parameter from the on_bool handler docs

### DIFF
--- a/include/boost/json/basic_parser.hpp
+++ b/include/boost/json/basic_parser.hpp
@@ -205,7 +205,6 @@ namespace json {
         ///
         /// @return `true` on success.
         /// @param b The value
-        /// @param s The remaining characters
         /// @param ec Set to the error, if any occurred.
         ///
         bool on_bool( bool b, error_code& ec );


### PR DESCRIPTION
The handler concept in `basic_parser.hpp` documents `on_bool` as taking the remaining characters:

```
/// Called when a boolean is parsed.
///
/// @return `true` on success.
/// @param b The value
/// @param s The remaining characters
/// @param ec Set to the error, if any occurred.
///
bool on_bool( bool b, error_code& ec );
```

There is no `s`. The line is a copy of the one in `on_double` right above it, which does take a `string_view`. `on_null` below has no such line, so `on_bool` is the only handler affected.

It matters a little more than a normal typo because this block is the specification users write their own handler against, so it tells them to expect an argument the parser never passes.

One line, comment only. I checked the rest of the library the same way and this is the only mismatch in it.
