### PR TITLE
fix deallocate alignment in string_impl::destroy

### DIFF
--- a/include/boost/json/detail/string_impl.hpp
+++ b/include/boost/json/detail/string_impl.hpp
@@ -267,7 +267,7 @@ public:
             // kind increases the cost of the destructor.
             // This function should be skipped when using
             // monotonic_resource.
-            sp->deallocate(k_.s, k_.n + 1);
+            sp->deallocate(k_.s, k_.n + 1, alignof(char));
         }
     }
 

--- a/test/parse.cpp
+++ b/test/parse.cpp
@@ -15,6 +15,7 @@
 
 #include <string>
 
+#include "checking_resource.hpp"
 #include "test.hpp"
 #include "test_suite.hpp"
 
@@ -203,12 +204,32 @@ public:
     }
 
     void
+    testAllocation()
+    {
+        // a key that is abandoned because the document is truncated still
+        // has to be returned to the resource with the size and alignment
+        // it was allocated with
+        {
+            checking_resource res;
+            system::error_code ec;
+            parse(R"({"some key here":)", ec, &res);
+        }
+
+        {
+            checking_resource res;
+            system::error_code ec;
+            parse(R"({"k":)", ec, &res);
+        }
+    }
+
+    void
     run()
     {
         testParse();
         testMemoryUsage();
         testIssue726();
         testIstream();
+        testAllocation();
     }
 };
 

--- a/test/parse.cpp
+++ b/test/parse.cpp
@@ -209,17 +209,9 @@ public:
         // a key that is abandoned because the document is truncated still
         // has to be returned to the resource with the size and alignment
         // it was allocated with
-        {
-            checking_resource res;
-            system::error_code ec;
-            parse(R"({"some key here":)", ec, &res);
-        }
-
-        {
-            checking_resource res;
-            system::error_code ec;
-            parse(R"({"k":)", ec, &res);
-        }
+        checking_resource res;
+        system::error_code ec;
+        parse(R"({"some key here":)", ec, &res);
     }
 
     void


### PR DESCRIPTION
Split out from #1179 as requested.

Repro: parse a truncated document like `{"some key here":` with `test/checking_resource.hpp` as the resource. The abandoned key fails `alignment == it->second.second`.

Cause: `string_impl::destroy` frees a key string with the default alignment (max_align), but both `key_t` constructors allocate it with `alignof(char)`. The default resource ignores the argument, so this only bites upstreams that bucket by alignment.

Fix: pass `alignof(char)` to match the allocation. Both test cases fail before the fix and pass after.