### PR TITLE
fix required member check for described structs in parse_into

### DIFF
--- a/include/boost/json/detail/parse_into.hpp
+++ b/include/boost/json/detail/parse_into.hpp
@@ -18,6 +18,7 @@
 #include <boost/json/value.hpp>
 #include <boost/describe/enum_from_string.hpp>
 
+#include <array>
 #include <vector>
 
 /*
@@ -1153,6 +1154,7 @@ private:
     handler_tuple<converting_handler, InnerHandlers> handlers_;
     int inner_active_ = -1;
     std::size_t activated_ = 0;
+    std::array<bool, mp11::mp_size<Dt>::value> seen_ = {};
 
 public:
     converting_handler( converting_handler const& ) = delete;
@@ -1183,8 +1185,11 @@ public:
         bool required_member = mp11::mp_with_index<InnerCount>(
             inner_active_,
             is_required_checker{});
-        if( required_member )
+        if( required_member && !seen_[inner_active_] )
+        {
+            seen_[inner_active_] = true;
             ++activated_;
+        }
 
         key_ = {};
         inner_active_ = -1;
@@ -1214,7 +1219,11 @@ public:
     bool on_object_begin( system::error_code& ec )
     {
         if( inner_active_ < 0 )
+        {
+            activated_ = 0;
+            seen_ = {};
             return true;
+        }
 
         BOOST_JSON_INVOKE_INNER( on_object_begin(ec) );
     }

--- a/include/boost/json/detail/parse_into.hpp
+++ b/include/boost/json/detail/parse_into.hpp
@@ -1153,7 +1153,6 @@ private:
 
     handler_tuple<converting_handler, InnerHandlers> handlers_;
     int inner_active_ = -1;
-    std::size_t activated_ = 0;
     std::bitset<mp11::mp_size<Dt>::value> seen_;
 
 public:
@@ -1185,11 +1184,8 @@ public:
         bool required_member = mp11::mp_with_index<InnerCount>(
             inner_active_,
             is_required_checker{});
-        if( required_member && !seen_[inner_active_] )
-        {
+        if( required_member )
             seen_[inner_active_] = true;
-            ++activated_;
-        }
 
         key_ = {};
         inner_active_ = -1;
@@ -1220,7 +1216,6 @@ public:
     {
         if( inner_active_ < 0 )
         {
-            activated_ = 0;
             seen_.reset();
             return true;
         }
@@ -1234,7 +1229,7 @@ public:
         {
             using C = mp11::mp_count_if<Dt, is_optional_like>;
             constexpr int N = mp11::mp_size<Dt>::value - C::value;
-            if( activated_ < N )
+            if( seen_.count() < N )
             {
                 BOOST_JSON_FAIL( ec, error::size_mismatch );
                 return false;

--- a/include/boost/json/detail/parse_into.hpp
+++ b/include/boost/json/detail/parse_into.hpp
@@ -1216,7 +1216,14 @@ public:
     {
         if( inner_active_ < 0 )
         {
-            seen_.reset();
+            // optional members count as seen from the start, so that at the
+            // end of the object seen_.all() means no required member is
+            // missing
+            mp11::mp_for_each< mp11::mp_iota< mp11::mp_size<Dt> > >(
+                [&](auto I) {
+                    using T = mp11::mp_at< Dt, decltype(I) >;
+                    seen_[I] = is_optional_like<T>::value;
+                });
             return true;
         }
 
@@ -1227,9 +1234,7 @@ public:
     {
         if( inner_active_ < 0 )
         {
-            using C = mp11::mp_count_if<Dt, is_optional_like>;
-            constexpr int N = mp11::mp_size<Dt>::value - C::value;
-            if( seen_.count() < N )
+            if( !seen_.all() )
             {
                 BOOST_JSON_FAIL( ec, error::size_mismatch );
                 return false;

--- a/include/boost/json/detail/parse_into.hpp
+++ b/include/boost/json/detail/parse_into.hpp
@@ -18,7 +18,7 @@
 #include <boost/json/value.hpp>
 #include <boost/describe/enum_from_string.hpp>
 
-#include <array>
+#include <bitset>
 #include <vector>
 
 /*
@@ -1154,7 +1154,7 @@ private:
     handler_tuple<converting_handler, InnerHandlers> handlers_;
     int inner_active_ = -1;
     std::size_t activated_ = 0;
-    std::array<bool, mp11::mp_size<Dt>::value> seen_ = {};
+    std::bitset<mp11::mp_size<Dt>::value> seen_;
 
 public:
     converting_handler( converting_handler const& ) = delete;
@@ -1221,7 +1221,7 @@ public:
         if( inner_active_ < 0 )
         {
             activated_ = 0;
-            seen_ = {};
+            seen_.reset();
             return true;
         }
 

--- a/test/parse_into.cpp
+++ b/test/parse_into.cpp
@@ -426,6 +426,24 @@ public:
                                                 {"b", 3.14f},
                                                 {"c", "hello"}}}};
         testParseIntoValue<W>(unexpected_jo);
+
+        system::error_code ec;
+        X x{};
+        parse_into(x, R"( {"a": 1, "a": 2, "a": 3} )", ec);
+        BOOST_TEST( ec == error::size_mismatch );
+
+        std::vector<X> v;
+        ec = {};
+        parse_into(
+            v, R"( [{"a": 1, "b": 1, "c": "one"}, {"a": 2}] )", ec);
+        BOOST_TEST( ec == error::size_mismatch );
+
+        ec = {};
+        parse_into(
+            v,
+            R"( [{"a": 1, "b": 1, "c": "one"}, {"a": 2, "b": 2, "c": "two"}] )",
+            ec);
+        BOOST_TEST( !ec.failed() ) && BOOST_TEST( v.size() == 2 );
 #endif
     }
 


### PR DESCRIPTION
Repro: `parse_into` a described struct whose members are all required, from `{"a": 1, "a": 2, "a": 3}`. It reports success, and `b` and `c` keep whatever the caller's object held. Same for `{"a": 2}` as the second element of `[{"a": 1, "b": 1, "c": "one"}, {"a": 2}]` parsed into `std::vector<X>`.
Cause: `activated_` counts values signalled rather than distinct members, and is never cleared, so a repeated key stands in for a missing one, and each object in a sequence starts from the previous object's count.
Fix: record which members have been set, and clear that record in `on_object_begin`, the way the sequence handler already clears its container in `on_array_begin`.
