### PR TITLE
fix dropped storage in single-element value(initializer_list)

### DIFF
--- a/include/boost/json/impl/value.ipp
+++ b/include/boost/json/impl/value.ipp
@@ -240,9 +240,8 @@ value(
     {
         if( init.size() == 1 )
         {
-            ::new(&sca_) scalar();
-            value temp = init.begin()->make_value( std::move(sp) );
-            swap(temp);
+            ::new(this) value(
+                init.begin()->make_value( std::move(sp) ));
         }
         else
         {

--- a/test/value.cpp
+++ b/test/value.cpp
@@ -545,6 +545,13 @@ public:
                 BOOST_TEST(jv.is_object());
                 BOOST_TEST(*jv.storage() == *sp);
             }
+            {
+                // a single-element list unwraps to that element and
+                // must still adopt the supplied storage
+                value jv({{1, 2, 3}}, sp);
+                BOOST_TEST(jv.is_array());
+                BOOST_TEST(*jv.storage() == *sp);
+            }
         }
     }
 


### PR DESCRIPTION
Repro: value jv({{1, 2, 3}}, sp) reports jv.storage() as the default resource rather than sp; the two-or-more element and object list forms adopt sp correctly.
Cause: the size()==1 branch of value(initializer_list<value_ref>, storage_ptr) constructs *this on the default resource with scalar(), builds the element on sp, then swaps; swap keeps each operand's own storage, so sp is discarded.
Fix: construct *this directly from the element's value, which already holds sp.