### PR TITLE
account for completed utf-8 sequence in parse_string size limit

### DIFF
--- a/include/boost/json/basic_parser_impl.hpp
+++ b/include/boost/json/basic_parser_impl.hpp
@@ -1110,6 +1110,7 @@ do_str8:
     }
     {
         std::size_t const n = seq_.length();
+        bool r;
         if(is_key)
         {
             BOOST_ASSERT(total <= Handler::max_key_size);
@@ -1120,6 +1121,8 @@ do_str8:
                     = BOOST_CURRENT_LOCATION;
                 return fail(cs.begin(), error::key_too_large, &loc);
             }
+            total += n;
+            r = h_.on_key_part( {seq_.data(), n}, total, ec_ );
         }
         else
         {
@@ -1131,11 +1134,9 @@ do_str8:
                     = BOOST_CURRENT_LOCATION;
                 return fail(cs.begin(), error::string_too_large, &loc);
             }
+            total += n;
+            r = h_.on_string_part( {seq_.data(), n}, total, ec_ );
         }
-        total += n;
-        bool const r = is_key?
-            h_.on_key_part( {seq_.data(), seq_.length()}, total, ec_ ):
-            h_.on_string_part( {seq_.data(), seq_.length()}, total, ec_ );
         if(BOOST_JSON_UNLIKELY( !r ))
             return fail( cs.begin() );
     }

--- a/include/boost/json/basic_parser_impl.hpp
+++ b/include/boost/json/basic_parser_impl.hpp
@@ -1109,6 +1109,30 @@ do_str8:
         return fail(cs.begin(), error::syntax, &loc);
     }
     {
+        std::size_t const n = seq_.length();
+        if(is_key)
+        {
+            BOOST_ASSERT(total <= Handler::max_key_size);
+            if(BOOST_JSON_UNLIKELY(n >
+                Handler::max_key_size - total))
+            {
+                BOOST_STATIC_CONSTEXPR source_location loc
+                    = BOOST_CURRENT_LOCATION;
+                return fail(cs.begin(), error::key_too_large, &loc);
+            }
+        }
+        else
+        {
+            BOOST_ASSERT(total <= Handler::max_string_size);
+            if(BOOST_JSON_UNLIKELY(n >
+                Handler::max_string_size - total))
+            {
+                BOOST_STATIC_CONSTEXPR source_location loc
+                    = BOOST_CURRENT_LOCATION;
+                return fail(cs.begin(), error::string_too_large, &loc);
+            }
+        }
+        total += n;
         bool const r = is_key?
             h_.on_key_part( {seq_.data(), seq_.length()}, total, ec_ ):
             h_.on_string_part( {seq_.data(), seq_.length()}, total, ec_ );

--- a/test/limits.cpp
+++ b/test/limits.cpp
@@ -353,6 +353,26 @@ public:
             BOOST_TEST(ec.has_location());
         }
 
+        // a key that reaches the limit exactly when the split multi-byte
+        // character completes on the str8 resume path is not an error
+        {
+            stream_parser p;
+            system::error_code ec;
+            std::string const big(string::max_size() - 2, '*');
+            p.write_some("{\"", 2, ec);
+            BOOST_TEST(! ec);
+            p.write_some(big.data(), big.size(), ec);
+            BOOST_TEST(! ec);
+            p.write_some("\xC3", 1, ec);
+            BOOST_TEST(! ec);
+            p.write_some("\xA9", 1, ec);
+            BOOST_TEST(! ec);
+            p.write_some("\":null}", 7, ec);
+            BOOST_TEST(! ec);
+            p.finish(ec);
+            BOOST_TEST(! ec);
+        }
+
         // object overflow
         {
             system::error_code ec;

--- a/test/limits.cpp
+++ b/test/limits.cpp
@@ -320,63 +320,38 @@ public:
             BOOST_TEST(ec.has_location());
         }
 
-        // a multi-byte utf-8 character split across a write boundary is
-        // completed on the str8 resume path; those bytes must still count
-        // towards the string/key size limit
+        // overflow on the str8 resume path; the multi-byte character is
+        // split across writes so that it completes on that path
         {
-            // feed one byte at a time so every "é" (0xC3 0xA9)
-            // straddles a chunk boundary
-            auto feed_split =
-                [](std::string const& body, system::error_code& ec)
-                {
-                    stream_parser p;
-                    for(char c : body)
-                    {
-                        p.write_some(&c, 1, ec);
-                        if(ec)
-                            return;
-                    }
-                    p.finish(ec);
-                };
-
-            // string: one character past the limit
-            {
-                std::string body = "\"";
-                for(std::size_t i = 0;
-                    i < (string::max_size() / 2) + 1; ++i)
-                    body += "\xC3\xA9";
-                body += "\"";
-                system::error_code ec;
-                feed_split(body, ec);
-                BOOST_TEST(ec == error::string_too_large);
-                BOOST_TEST(ec.has_location());
-            }
-
-            // key: one character past the limit
-            {
-                std::string body = "{\"";
-                for(std::size_t i = 0;
-                    i < (string::max_size() / 2) + 1; ++i)
-                    body += "\xC3\xA9";
-                body += "\":null}";
-                system::error_code ec;
-                feed_split(body, ec);
-                BOOST_TEST(ec == error::key_too_large);
-                BOOST_TEST(ec.has_location());
-            }
-
-            // a split multi-byte string within the limit still parses
-            {
-                std::string body = "\"";
-                for(std::size_t i = 0; i < 8; ++i)
-                    body += "\xC3\xA9";
-                body += "\"";
-                system::error_code ec;
-                feed_split(body, ec);
-                BOOST_TEST(! ec);
-            }
+            stream_parser p;
+            system::error_code ec;
+            std::string const big(string::max_size(), '*');
+            p.write_some("\"", 1, ec);
+            BOOST_TEST(! ec);
+            p.write_some(big.data(), big.size(), ec);
+            BOOST_TEST(! ec);
+            p.write_some("\xC3", 1, ec);
+            BOOST_TEST(! ec);
+            p.write_some("\xA9", 1, ec);
+            BOOST_TEST(ec == error::string_too_large);
+            BOOST_TEST(ec.has_location());
         }
 
+        // likewise for a key
+        {
+            stream_parser p;
+            system::error_code ec;
+            std::string const big(string::max_size(), '*');
+            p.write_some("{\"", 2, ec);
+            BOOST_TEST(! ec);
+            p.write_some(big.data(), big.size(), ec);
+            BOOST_TEST(! ec);
+            p.write_some("\xC3", 1, ec);
+            BOOST_TEST(! ec);
+            p.write_some("\xA9", 1, ec);
+            BOOST_TEST(ec == error::key_too_large);
+            BOOST_TEST(ec.has_location());
+        }
 
         // object overflow
         {

--- a/test/limits.cpp
+++ b/test/limits.cpp
@@ -320,6 +320,63 @@ public:
             BOOST_TEST(ec.has_location());
         }
 
+        // a multi-byte utf-8 character split across a write boundary is
+        // completed on the str8 resume path; those bytes must still count
+        // towards the string/key size limit
+        {
+            // feed one byte at a time so every "é" (0xC3 0xA9)
+            // straddles a chunk boundary
+            auto feed_split =
+                [](std::string const& body, system::error_code& ec)
+                {
+                    stream_parser p;
+                    for(char c : body)
+                    {
+                        p.write_some(&c, 1, ec);
+                        if(ec)
+                            return;
+                    }
+                    p.finish(ec);
+                };
+
+            // string: one character past the limit
+            {
+                std::string body = "\"";
+                for(std::size_t i = 0;
+                    i < (string::max_size() / 2) + 1; ++i)
+                    body += "\xC3\xA9";
+                body += "\"";
+                system::error_code ec;
+                feed_split(body, ec);
+                BOOST_TEST(ec == error::string_too_large);
+                BOOST_TEST(ec.has_location());
+            }
+
+            // key: one character past the limit
+            {
+                std::string body = "{\"";
+                for(std::size_t i = 0;
+                    i < (string::max_size() / 2) + 1; ++i)
+                    body += "\xC3\xA9";
+                body += "\":null}";
+                system::error_code ec;
+                feed_split(body, ec);
+                BOOST_TEST(ec == error::key_too_large);
+                BOOST_TEST(ec.has_location());
+            }
+
+            // a split multi-byte string within the limit still parses
+            {
+                std::string body = "\"";
+                for(std::size_t i = 0; i < 8; ++i)
+                    body += "\xC3\xA9";
+                body += "\"";
+                system::error_code ec;
+                feed_split(body, ec);
+                BOOST_TEST(! ec);
+            }
+        }
+
 
         // object overflow
         {


### PR DESCRIPTION
Repro: feed a multi-byte UTF-8 string to `stream_parser` one byte at a time, so each character completes across a `write_some` boundary; `max_string_size`/`max_key_size` is not applied to it and `on_string_part`/`on_key_part` report a `total` that omits those bytes.
Cause: the `str8` resume path in `parse_string` (completing a UTF-8 sequence split across a chunk) emits `seq_.length()` bytes to the handler without bounds-checking them or adding them to `total`. `do_str1` and `parse_escaped` both account before their handler calls; `str8` was the gap.
Fix: on the `str8` path, check `seq_.length()` against the remaining budget and add it to `total` before emitting, matching `do_str1`.

Regression test in `test/limits.cpp` drives split multi-byte strings and keys through `stream_parser` a byte at a time; the size limits are skipped before the change and enforced after.