### PR TITLE
forward mapped value in object::insert_or_assign assign branch

### DIFF
--- a/include/boost/json/impl/object.hpp
+++ b/include/boost/json/impl/object.hpp
@@ -398,7 +398,7 @@ insert_or_assign(
         key, key, static_cast<M&&>(m) );
     if( !result.second )
     {
-        value(static_cast<M>(m), sp_).swap(
+        value(static_cast<M&&>(m), sp_).swap(
             result.first->value());
     }
     return result;

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -1201,6 +1201,17 @@ public:
                     { "k3", 3 },
                     { "k4", 2 }}));
             }
+
+            // rvalue is moved, not copied, on the assign branch
+            {
+                object o = {
+                    { "k1", 1 },
+                    { "k2", { 1, 2, 3 } } };
+                value v = { 4, 5, 6 };
+                o.insert_or_assign("k2", std::move(v));
+                BOOST_TEST(o.at("k2") == (array{4, 5, 6}));
+                BOOST_TEST(v.as_array().empty());
+            }
         }
 
         // emplace(key, arg)

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -1208,9 +1208,10 @@ public:
                     { "k1", 1 },
                     { "k2", { 1, 2, 3 } } };
                 value v = { 4, 5, 6 };
+                auto const d = v.as_array().data();
                 o.insert_or_assign("k2", std::move(v));
                 BOOST_TEST(o.at("k2") == (array{4, 5, 6}));
-                BOOST_TEST(v.as_array().empty());
+                BOOST_TEST(o.at("k2").as_array().data() == d);
             }
         }
 

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -1210,7 +1210,6 @@ public:
                 value v = { 4, 5, 6 };
                 auto const d = v.as_array().data();
                 o.insert_or_assign("k2", std::move(v));
-                BOOST_TEST(o.at("k2") == (array{4, 5, 6}));
                 BOOST_TEST(o.at("k2").as_array().data() == d);
             }
         }


### PR DESCRIPTION
Repro: `insert_or_assign(key, std::move(v))` on an existing key, with `v` on the object's own resource, deep-copies `v` and leaves it intact instead of moving it. For a 100-element array the assign branch runs 101 allocations and the source array is still populated afterwards.
Cause: the assign branch casts the mapped value to `M` rather than `M&&`, so for an rvalue argument it selects `value(value const&)`, which allocates a copy on the source's storage before the copy into `sp_`. The insert branch one line above already forwards with `M&&`.
Fix: cast to `M&&` to match the insert branch. The stored value is unchanged; the redundant copy and the ignored move go away.