### PR TITLE
account for alignment padding in monotonic_resource::do_allocate

### DIFF
--- a/include/boost/json/impl/monotonic_resource.ipp
+++ b/include/boost/json/impl/monotonic_resource.ipp
@@ -14,8 +14,10 @@
 #include <boost/json/monotonic_resource.hpp>
 #include <boost/json/detail/except.hpp>
 #include <boost/core/max_align.hpp>
+#include <boost/throw_exception.hpp>
 
 #include <memory>
+#include <new>
 
 namespace boost {
 namespace json {
@@ -128,8 +130,15 @@ do_allocate(
         return p;
     }
 
-    if(next_size_ < n)
-        next_size_ = round_pow2(n);
+    // a new block is only aligned to alignof(block), so an
+    // over-aligned request may need up to align - alignof(block)
+    // bytes of padding in addition to n
+    std::size_t const pad = align > alignof(block)
+        ? align - alignof(block) : 0;
+    if(n > max_size() - pad)
+        throw_exception( std::bad_alloc(), BOOST_CURRENT_LOCATION );
+    if(next_size_ < n + pad)
+        next_size_ = round_pow2(n + pad);
     auto b = ::new(upstream_->allocate(
         sizeof(block) + next_size_)) block;
     b->p = b + 1;

--- a/test/monotonic_resource.cpp
+++ b/test/monotonic_resource.cpp
@@ -17,6 +17,7 @@
 #include <boost/json/serialize.hpp>
 #include <boost/core/max_align.hpp>
 #include <iostream>
+#include <new>
 
 #include "checking_resource.hpp"
 #include "test_suite.hpp"
@@ -318,12 +319,36 @@ R"xx({
     }
 
     void
+    testOverAligned()
+    {
+        // an over-aligned request that fills a fresh block needs
+        // room for the padding in addition to the requested size
+        for(std::size_t align = 2 * alignof(core::max_align_t);
+            align <= 4096; align *= 2)
+        {
+            monotonic_resource mr;
+            void* p = mr.allocate(1024, align);
+            BOOST_TEST(p != nullptr);
+            BOOST_TEST(
+                !(reinterpret_cast<std::uintptr_t>(p) % align));
+        }
+        // the padding must not make the request overflow
+        {
+            monotonic_resource mr;
+            BOOST_TEST_THROWS(
+                mr.allocate(std::size_t(-1) - 100, 4096),
+                std::bad_alloc);
+        }
+    }
+
+    void
     run()
     {
         testMembers();
         testStorage();
         testGeneral();
         testAllocation();
+        testOverAligned();
     }
 };
 


### PR DESCRIPTION
Repro: `monotonic_resource mr; mr.allocate(1024, 64);` returns a null pointer in release builds and trips `BOOST_ASSERT(p)` in debug (UBSan: "applying non-zero offset 1024 to null pointer" at monotonic_resource.ipp:145). The same happens through `pmr::polymorphic_allocator<T>` for any `T` with `alignof(T) > alignof(max_align_t)` once a pmr vector grows to a power-of-two byte size.
Cause: `do_allocate` sizes a fresh block from `n` alone, but the block payload is only `alignof(block)` aligned, so `std::align` on the new block has no room for the padding an over-aligned request needs whenever `n + padding > next_size_`.
Fix: include the worst-case padding (`align - alignof(block)`) when choosing the block size, and reject a padded size that would overflow with `bad_alloc`, as `static_resource` already does. The added test allocates 1024 bytes at alignments from `2 * max_align` to 4096 from fresh resources; it fails 7 assertions before the change and passes after.
