### PR TITLE
fix array index overflow in set_at_pointer

### DIFF
--- a/include/boost/json/impl/pointer.ipp
+++ b/include/boost/json/impl/pointer.ipp
@@ -455,11 +455,13 @@ value::set_at_pointer(
                 if( n >= opts.max_created_elements )
                     return nullptr;
 
-                // arr.size() + n + 1 equals index + 1; reject the value that
-                // would wrap so the resize count and the returned pointer stay
-                // in bounds
-                if( index == std::size_t(-1) )
+                // the resulting size, index + 1, would either exceed the
+                // array's size limit or wrap to 0 when index == size_t(-1)
+                if( index >= array::max_size() )
+                {
+                    BOOST_JSON_FAIL( ec, error::array_too_large );
                     return nullptr;
+                }
 
                 arr.resize( arr.size() + n + 1 );
             }

--- a/include/boost/json/impl/pointer.ipp
+++ b/include/boost/json/impl/pointer.ipp
@@ -455,6 +455,12 @@ value::set_at_pointer(
                 if( n >= opts.max_created_elements )
                     return nullptr;
 
+                // arr.size() + n + 1 equals index + 1; reject the value that
+                // would wrap so the resize count and the returned pointer stay
+                // in bounds
+                if( index == std::size_t(-1) )
+                    return nullptr;
+
                 arr.resize( arr.size() + n + 1 );
             }
 

--- a/test/pointer.cpp
+++ b/test/pointer.cpp
@@ -327,7 +327,7 @@ public:
             system::error_code ec;
             result = jv.set_at_pointer(ptr, 1, ec, opts);
             BOOST_TEST( !result );
-            BOOST_TEST( ec == error::not_found );
+            BOOST_TEST( ec == error::array_too_large );
             BOOST_TEST( hasLocation(ec) );
             BOOST_TEST(( jv == array{0} ));
         }

--- a/test/pointer.cpp
+++ b/test/pointer.cpp
@@ -312,6 +312,26 @@ public:
         BOOST_TEST( *result == 0 );
         BOOST_TEST( result == &jv.at_pointer("/4") );
 
+        // an index equal to std::size_t(-1) makes the element count index + 1
+        // wrap to zero; the array must not be resized and no pointer past its
+        // end may be returned
+        opts = {};
+        opts.max_created_elements = std::size_t(-1);
+        jv = array{0};
+        {
+            std::string const ptr =
+                "/" + std::to_string(std::size_t(-1));
+            BOOST_TEST_THROWS_WITH_LOCATION( jv.set_at_pointer(ptr, 1, opts) );
+            BOOST_TEST(( jv == array{0} ));
+
+            system::error_code ec;
+            result = jv.set_at_pointer(ptr, 1, ec, opts);
+            BOOST_TEST( !result );
+            BOOST_TEST( ec == error::not_found );
+            BOOST_TEST( hasLocation(ec) );
+            BOOST_TEST(( jv == array{0} ));
+        }
+
         opts = {};
         opts.create_arrays = false;
         opts.create_objects = false;


### PR DESCRIPTION
Repro: call `set_at_pointer` on a non-empty array with an index token equal to `std::size_t(-1)`, e.g. `"/18446744073709551615"` on a 64-bit build, and a `max_created_elements` large enough to pass the element-count guard.

Cause: the guard bounds `n` (the number of elements to create) but not `index + 1`. `arr.size() + n + 1` is `index + 1`, which wraps to `0`, so `resize` takes the shrink branch (skipping the `array_too_large` check) and the lambda returns `arr.data() + index`, a pointer one element before the buffer. The following `*result = ref.make_value(...)` then writes through it (ASAN: heap-buffer-overflow in `value::operator=` via pointer.ipp:490; UBSan: unsigned pointer overflow at pointer.ipp:462).

Fix: reject `index >= array::max_size()` before the resize and fail with `error::array_too_large`, next to the existing `max_created_elements` check. Regression test drives index `std::size_t(-1)` on a non-empty array and checks the array is untouched and `error::array_too_large` is returned.