### PR TITLE
align caller-supplied buffer in value_stack::stack

### DIFF
--- a/include/boost/json/impl/value_stack.ipp
+++ b/include/boost/json/impl/value_stack.ipp
@@ -12,6 +12,7 @@
 
 #include <boost/json/value_stack.hpp>
 #include <cstring>
+#include <memory>
 #include <stdexcept>
 #include <utility>
 
@@ -40,11 +41,15 @@ stack(
     void* temp,
     std::size_t size) noexcept
     : sp_(std::move(sp))
-    , temp_(temp)
 {
-    if(size >= min_size_ *
-        sizeof(value))
+    // the buffer stores `value`s, so it has to be aligned for one;
+    // align it up the same way static_resource does for its buffer
+    if(std::align(
+        alignof(value),
+        min_size_ * sizeof(value),
+        temp, size))
     {
+        temp_ = temp;
         begin_ = reinterpret_cast<
             value*>(temp);
         top_ = begin_;
@@ -53,6 +58,7 @@ stack(
     }
     else
     {
+        temp_ = temp;
         begin_ = nullptr;
         top_ = nullptr;
         end_ = nullptr;

--- a/test/value_stack.cpp
+++ b/test/value_stack.cpp
@@ -118,9 +118,32 @@ public:
     }
 
     void
+    testAlignment()
+    {
+        // a caller-supplied buffer is used to store `value`s, so the stack
+        // must cope with a buffer that is not aligned for one. Walk every
+        // misalignment; before the fix the odd offsets construct a `value`
+        // at a misaligned address (UBSan: misaligned constructor call).
+        alignas(value) unsigned char buf[4096 + alignof(value)];
+        for(std::size_t off = 0; off < alignof(value); ++off)
+        {
+            value_stack st(
+                storage_ptr(), buf + off, sizeof(buf) - off);
+            st.reset();
+            st.push_int64(1);
+            st.push_int64(2);
+            st.push_int64(3);
+            st.push_array(3);
+            value const jv = st.release();
+            BOOST_TEST(serialize(jv) == "[1,2,3]");
+        }
+    }
+
+    void
     run()
     {
         testValueStack();
+        testAlignment();
     }
 };
 


### PR DESCRIPTION
Repro: hand any of the buffer-taking parser / stream_parser / value_stack constructors a buffer that is not aligned for `value` (`buf + 1`, a heap block, a sub-buffer) and parse a small array. UBSan reports `constructor call on misaligned address ... for type boost::json::value, which requires 8 byte alignment` at `detail/value.hpp:229`, via `value_stack::stack::push`.

Cause: `value_stack::stack` stores `value` objects in the caller-owned buffer but reinterprets it as `value*` without aligning the pointer. `static_resource::do_allocate` and `monotonic_resource` both align a caller buffer through `std::align`; this constructor was the one that skipped it, and the buffer overloads document the parameter only as "a pointer to valid storage".

Fix: align the buffer up to `alignof(value)` with `std::align`, keeping `min_size_ * sizeof(value)` usable bytes, and fall back to the memory resource when the aligned region is too small.

Regression test walks every misalignment of a value-sized buffer and parses `[1,2,3]`; the odd offsets trip UBSan before the change and pass after.