### PR TITLE
fix array end handling for first variant alternative in parse_into

### DIFF
--- a/include/boost/json/detail/parse_into.hpp
+++ b/include/boost/json/detail/parse_into.hpp
@@ -1601,7 +1601,7 @@ public:
 
     bool on_array_end( system::error_code& ec )
     {
-        if( !inner_active_ )
+        if( inner_active_ < 0 )
             return signal_end(ec);
 
         BOOST_JSON_INVOKE_INNER( array_end_handler_event{}, ec );

--- a/test/parse_into.cpp
+++ b/test/parse_into.cpp
@@ -16,6 +16,7 @@
 #include <boost/json/value_to.hpp>
 #include <boost/describe.hpp>
 
+#include <array>
 #include <climits>
 #include <map>
 
@@ -478,6 +479,16 @@ public:
 
         testParseInto< std::vector< Variant<int, std::string> > >(
             {1, 2, 3, "four", 5, "six", "seven", 8});
+
+        // an array-like first alternative nested in a composite
+        testParseInto< std::vector< Variant<std::vector<int>, int> > >(
+            { std::vector<int>{1}, 2 } );
+        testParseInto< std::map<std::string, Variant<std::vector<int>, int> > >(
+            { { "a", std::vector<int>{1, 2} }, { "b", 3 } } );
+
+        // an incomplete array must not satisfy a fixed-size alternative
+        testParseIntoErrors< Variant< std::array<int, 3> > >(
+            error::exhausted_variants, {1} );
 
         using V = Variant<
             std::vector< int >,


### PR DESCRIPTION
Repro: parse_into a `std::vector<variant2::variant<std::vector<int>, int>>` from `[[1],2]`; it fails with `error::not_array`, while the alternatives-swapped `variant<int, std::vector<int>>` accepts the same document. A `variant<std::array<int,3>>` parsed from `[1]` reports success and leaves two elements unwritten; nesting such a variant in a map trips the `BOOST_ASSERT(false)` path in `handler_error_base::on_object_end` on debug builds.
Cause: the variant handler's `on_array_end` tests its `int` sentinel with `!inner_active_`, which is only true for index 0, so while the first alternative is mid-array its closing bracket is routed to `signal_end` and terminates the variant instead of reaching the active alternative. The completeness check of the aborted alternative never runs.
Fix: compare `inner_active_ < 0`, matching the sentinel checks elsewhere in the file. The added tests fail before the change and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7uBZYRF8M5U3w49QLn4nW